### PR TITLE
♻️ Refactor/#125 퀴즈 생성 type response ENUM 형식으로 변경

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -42,7 +42,7 @@ services:
 #      retries: 10
 
   ai:
-    image: classlog/ai:v1.2
+    image: classlog/ai:v1.3
     container_name: classlog-ai
     ports:
       - 8000:8000

--- a/backend/src/main/java/org/example/backend/infra/langchain/LangChainClientImpl.java
+++ b/backend/src/main/java/org/example/backend/infra/langchain/LangChainClientImpl.java
@@ -61,9 +61,9 @@ public class LangChainClientImpl implements LangChainClient {
                         String rawType = (String) q.get("type");
                         String mappedType;
                         switch (rawType) {
-                            case "객관식" -> mappedType = "MULTIPLE_CHOICE";
-                            case "단답형" -> mappedType = "SHORT_ANSWER";
-                            case "OX", "참/거짓", "참거짓", "True/False" -> mappedType = "TRUE_FALSE";
+                            case "객관식" -> mappedType = "multipleChoice";
+                            case "단답형" -> mappedType = "shortAnswer";
+                            case "OX", "참/거짓", "참거짓", "True/False" -> mappedType = "trueFalse";
                             default -> mappedType = "UNKNOWN";
                         }
 

--- a/backend/src/main/java/org/example/backend/infra/langchain/LangChainClientImpl.java
+++ b/backend/src/main/java/org/example/backend/infra/langchain/LangChainClientImpl.java
@@ -58,10 +58,19 @@ public class LangChainClientImpl implements LangChainClient {
                             choices = Collections.emptyList();
                         }
 
+                        String rawType = (String) q.get("type");
+                        String mappedType;
+                        switch (rawType) {
+                            case "객관식" -> mappedType = "MULTIPLE_CHOICE";
+                            case "단답형" -> mappedType = "SHORT_ANSWER";
+                            case "OX", "참/거짓", "참거짓", "True/False" -> mappedType = "TRUE_FALSE";
+                            default -> mappedType = "UNKNOWN";
+                        }
+
                         return QuizDTO.builder()
                                 .quizBody((String) q.get("quiz_body"))
                                 .solution((String) q.get("solution"))
-                                .type((String) q.get("type"))
+                                .type(mappedType)
                                 .choices(choices)
                                 .build();
                     })


### PR DESCRIPTION
### 👀 관련 이슈

#125 
<!-- 관련 이슈를 적어주세요 -->

### ✨ 작업한 내용

[Docker AI image 변경](https://github.com/KW-ClassLog/ClassLog/commit/625d1910ec099705e48c54b7049284c9fdd567ae)
[퀴즈 생성 response type enum으로 변경](https://github.com/KW-ClassLog/ClassLog/commit/53b26a89fd9e2a437bf20efaf0d2c3e79d5020f7)

<!-- 작업한 내용을 적어주세요 -->

### 🌀 PR Point

/api/quizzes/{lecture_id}/create 테스트 후 type이 ENUM으로 바꼈는지 확인해주세요.

객관식: multipleChoice
단답형: shortAnswer
OX: trueFalse
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

response 결과가 잘 뜨면 AI 레포 pr 수락도 같이 부탁드립니다.

<!-- 참고할 사항이 있다면 적어주세요 -->
