### PR TITLE
✨ Feat/#133 퀴즈 제출 학생 목록 조회 구현

### DIFF
--- a/backend/src/main/java/org/example/backend/domain/quiz/controller/QuizController.java
+++ b/backend/src/main/java/org/example/backend/domain/quiz/controller/QuizController.java
@@ -6,7 +6,9 @@ import org.example.backend.domain.quiz.dto.request.QuizSaveRequestDTO;
 import org.example.backend.domain.quiz.dto.response.QuizResponseDTO;
 import org.example.backend.domain.quiz.dto.response.QuizSaveResponseDTO;
 import org.example.backend.domain.quiz.exception.QuizException;
+import org.example.backend.domain.quiz.service.QuizResultService;
 import org.example.backend.domain.quiz.service.QuizService;
+import org.example.backend.domain.quiz.dto.response.QuizSubmitListResponseDTO;
 import org.example.backend.global.ApiResponse;
 import org.example.backend.global.code.base.FailureCode;
 import org.springframework.http.ResponseEntity;
@@ -20,7 +22,9 @@ import java.util.UUID;
 public class QuizController {
 
     private final QuizService quizService;
+    private final QuizResultService quizResultService;
 
+    // 퀴즈 생성
     @PostMapping("/{lectureId}/create")
     public ResponseEntity<ApiResponse<QuizResponseDTO>> generateQuiz(@PathVariable UUID lectureId,
                                                                      @RequestBody QuizRequestDTO request) {
@@ -38,6 +42,7 @@ public class QuizController {
         }
     }
 
+    // 퀴즈 저장
     @PostMapping("/{lectureId}")
     public ResponseEntity<ApiResponse<QuizSaveResponseDTO>> saveQuiz(@PathVariable UUID lectureId,
                                                             @RequestBody QuizSaveRequestDTO request) {
@@ -50,6 +55,23 @@ public class QuizController {
                     .body(ApiResponse.onFailure(e.getErrorCode()));
         } catch (Exception e) {
             e.printStackTrace();
+            return ResponseEntity
+                    .status(FailureCode._INTERNAL_SERVER_ERROR.getReasonHttpStatus().getHttpStatus())
+                    .body(ApiResponse.onFailure(FailureCode._INTERNAL_SERVER_ERROR));
+        }
+    }
+
+    // 퀴즈 제출 학생 목록 조회
+    @GetMapping("/{lectureId}/result/list")
+    public ResponseEntity<ApiResponse<QuizSubmitListResponseDTO>> getQuizSubmitList(@PathVariable UUID lectureId) {
+        try {
+            QuizSubmitListResponseDTO result = quizResultService.getQuizSubmitList(lectureId);
+            return ResponseEntity.ok(ApiResponse.onSuccess(result));
+        } catch (QuizException e) {
+            return ResponseEntity
+                    .status(e.getErrorCode().getReasonHttpStatus().getHttpStatus())
+                    .body(ApiResponse.onFailure(e.getErrorCode()));
+        } catch (Exception e) {
             return ResponseEntity
                     .status(FailureCode._INTERNAL_SERVER_ERROR.getReasonHttpStatus().getHttpStatus())
                     .body(ApiResponse.onFailure(FailureCode._INTERNAL_SERVER_ERROR));

--- a/backend/src/main/java/org/example/backend/domain/quiz/dto/response/QuizSubmitListResponseDTO.java
+++ b/backend/src/main/java/org/example/backend/domain/quiz/dto/response/QuizSubmitListResponseDTO.java
@@ -1,0 +1,26 @@
+package org.example.backend.domain.quiz.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class QuizSubmitListResponseDTO {
+    private UUID lectureId;
+    private int submitNum;
+    private List<StudentSubmitDTO> studentList;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class StudentSubmitDTO {
+        private String name;
+        private LocalDateTime submitDate;
+    }
+}

--- a/backend/src/main/java/org/example/backend/domain/quiz/exception/QuizErrorCode.java
+++ b/backend/src/main/java/org/example/backend/domain/quiz/exception/QuizErrorCode.java
@@ -11,6 +11,7 @@ public enum QuizErrorCode implements BaseErrorCode {
     LECTURE_NOT_FOUND(HttpStatus.NOT_FOUND, "LECTURE404_1", "해당 강의를 찾을 수 없습니다."),
     LECTURE_NOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "LECTURE404_2", "해당 강의에 등록된 강의록을 찾을 수 없습니다."),
     STUDENT_NOT_CREATE_QUIZ(HttpStatus.BAD_REQUEST, "QUIZ403_1", "강사만 퀴즈를 생성할 수 있습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "QUIZ403_2", "접근 권한이 없습니다."),
     INVALID_QUIZ_TYPE(HttpStatus.BAD_REQUEST, "QUIZ400_1", "잘못된 퀴즈 유형입니다."),
     AI_CALL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI_500", "AI 호출 중 오류가 발생했습니다.");
 

--- a/backend/src/main/java/org/example/backend/domain/quiz/repository/QuizRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/quiz/repository/QuizRepository.java
@@ -2,7 +2,10 @@ package org.example.backend.domain.quiz.repository;
 
 import org.example.backend.domain.quiz.entity.Quiz;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 import java.util.UUID;
 
 public interface QuizRepository extends JpaRepository<Quiz, UUID> {
+    List<Quiz> findByLectureId(UUID lectureId);
 }

--- a/backend/src/main/java/org/example/backend/domain/quiz/service/QuizResultService.java
+++ b/backend/src/main/java/org/example/backend/domain/quiz/service/QuizResultService.java
@@ -1,0 +1,9 @@
+package org.example.backend.domain.quiz.service;
+
+import org.example.backend.domain.quiz.dto.response.QuizSubmitListResponseDTO;
+
+import java.util.UUID;
+
+public interface QuizResultService {
+    QuizSubmitListResponseDTO getQuizSubmitList(UUID lectureId);
+}

--- a/backend/src/main/java/org/example/backend/domain/quiz/service/QuizResultServiceImpl.java
+++ b/backend/src/main/java/org/example/backend/domain/quiz/service/QuizResultServiceImpl.java
@@ -53,6 +53,7 @@ public class QuizResultServiceImpl implements QuizResultService {
                             .submitDate(answer.getCreatedAt())
                             .build();
                 })
+                .sorted((a, b) -> a.getSubmitDate().compareTo(b.getSubmitDate()))
                 .toList();
 
         return QuizSubmitListResponseDTO.builder()

--- a/backend/src/main/java/org/example/backend/domain/quiz/service/QuizResultServiceImpl.java
+++ b/backend/src/main/java/org/example/backend/domain/quiz/service/QuizResultServiceImpl.java
@@ -1,0 +1,64 @@
+package org.example.backend.domain.quiz.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.domain.lecture.entity.Lecture;
+import org.example.backend.domain.lecture.repository.LectureRepository;
+import org.example.backend.domain.quiz.entity.Quiz;
+import org.example.backend.domain.quiz.exception.QuizErrorCode;
+import org.example.backend.domain.quiz.exception.QuizException;
+import org.example.backend.domain.quiz.repository.QuizRepository;
+import org.example.backend.domain.quiz.dto.response.QuizSubmitListResponseDTO;
+import org.example.backend.domain.quizAnswer.entity.QuizAnswer;
+import org.example.backend.domain.quizAnswer.repository.QuizAnswerRepository;
+import org.example.backend.domain.user.entity.User;
+import org.example.backend.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class QuizResultServiceImpl implements QuizResultService {
+
+    private final LectureRepository lectureRepository;
+    private final QuizRepository quizRepository;
+    private final QuizAnswerRepository quizAnswerRepository;
+    private final UserRepository userRepository;
+
+    // 퀴즈 제출 학생 목록 조회
+    @Override
+    public QuizSubmitListResponseDTO getQuizSubmitList(UUID lectureId) {
+        Lecture lecture = lectureRepository.findById(lectureId)
+                .orElseThrow(() -> new QuizException(QuizErrorCode.LECTURE_NOT_FOUND));
+
+        List<Quiz> quizzes = quizRepository.findByLectureId(lectureId);
+        if (quizzes.isEmpty()) {
+            return QuizSubmitListResponseDTO.builder()
+                    .lectureId(lectureId)
+                    .submitNum(0)
+                    .studentList(List.of())
+                    .build();
+        }
+
+        UUID quizId = quizzes.get(0).getId();
+        List<QuizAnswer> answers = quizAnswerRepository.findAllByQuizId(quizId);
+
+        List<QuizSubmitListResponseDTO.StudentSubmitDTO> studentList = answers.stream()
+                .map(answer -> {
+                    User user = userRepository.findById(answer.getUser().getId())
+                            .orElseThrow();
+                    return QuizSubmitListResponseDTO.StudentSubmitDTO.builder()
+                            .name(user.getName())
+                            .submitDate(answer.getCreatedAt())
+                            .build();
+                })
+                .toList();
+
+        return QuizSubmitListResponseDTO.builder()
+                .lectureId(lectureId)
+                .submitNum(studentList.size())
+                .studentList(studentList)
+                .build();
+    }
+}

--- a/backend/src/main/java/org/example/backend/domain/quiz/service/QuizServiceImpl.java
+++ b/backend/src/main/java/org/example/backend/domain/quiz/service/QuizServiceImpl.java
@@ -48,14 +48,18 @@ public class QuizServiceImpl implements QuizService {
     public QuizResponseDTO generateQuiz(UUID lectureId, QuizRequestDTO request) {
 
         Role role = customSecurityUtil.getUserRole();
+        UUID userId = customSecurityUtil.getUserId();
 
         if (role == Role.STUDENT) {
             throw new QuizException(QuizErrorCode.STUDENT_NOT_CREATE_QUIZ);
         }
 
-        // 강의 존재 여부 확인
         Lecture lecture = lectureRepository.findById(lectureId)
                 .orElseThrow(() -> new QuizException(QuizErrorCode.LECTURE_NOT_FOUND));
+
+        if (!lecture.getClassroom().getProfessor().getId().equals(userId)) {
+            throw new QuizException(QuizErrorCode.UNAUTHORIZED_ACCESS);
+        }
 
         // 강의록 매핑 존재 여부 확인
         List<LectureNoteMapping> mappings = lectureNoteMappingRepository.findAllByLectureId(lectureId);
@@ -99,6 +103,8 @@ public class QuizServiceImpl implements QuizService {
     public QuizSaveResponseDTO saveQuiz(UUID lectureId, QuizSaveRequestDTO request) {
 
         Role role = customSecurityUtil.getUserRole();
+        UUID userId = customSecurityUtil.getUserId();
+
 
         if (role == Role.STUDENT) {
             throw new QuizException(QuizErrorCode.STUDENT_NOT_CREATE_QUIZ);
@@ -106,6 +112,10 @@ public class QuizServiceImpl implements QuizService {
 
         Lecture lecture = lectureRepository.findById(lectureId)
                 .orElseThrow(() -> new QuizException(QuizErrorCode.LECTURE_NOT_FOUND));
+
+        if (!lecture.getClassroom().getProfessor().getId().equals(userId)) {
+            throw new QuizException(QuizErrorCode.UNAUTHORIZED_ACCESS);
+        }
 
         List<UUID> savedQuizIds = new ArrayList<>();
 

--- a/backend/src/main/java/org/example/backend/domain/quizAnswer/repository/QuizAnswerRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/quizAnswer/repository/QuizAnswerRepository.java
@@ -1,4 +1,13 @@
 package org.example.backend.domain.quizAnswer.repository;
 
-public interface QuizAnswerRepository {
+import org.example.backend.domain.quizAnswer.entity.QuizAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+
+public interface QuizAnswerRepository extends JpaRepository<QuizAnswer, UUID> {
+    List<QuizAnswer> findAllByQuizId(UUID quizId);
 }


### PR DESCRIPTION
### 👀 관련 이슈

#133 
<!-- 관련 이슈를 적어주세요 -->

### ✨ 작업한 내용

[퀴즈 제출 학생 목록 조회 로직 추가](https://github.com/KW-ClassLog/ClassLog/commit/6a778bf32a0310f11cd1807d1eb30ce825b6133b)
[퀴즈 정답 Repository 설정](https://github.com/KW-ClassLog/ClassLog/commit/7fc839382497bb6777b614a3bbdfafcb6c292240)
[응답 퀴즈 제출순으로 정렬](https://github.com/KW-ClassLog/ClassLog/commit/bbaadc851ddcd8c588a1249d9d9b9c1cf7858167)
[강사만 조회 가능하고 본인의 강의만 접근 가능하도록 예외 처리](https://github.com/KW-ClassLog/ClassLog/commit/125fb174560a321316441bf7888983f13e439ac9)

<!-- 작업한 내용을 적어주세요 -->

### 🌀 PR Point

/api/quizzes/{lecture_id}/result/list 테스트 해주세요.
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

quiz_answer 테이블 목업 데이터 넣고 테스트 진행해야합니다.
<!-- 참고할 사항이 있다면 적어주세요 -->