### PR TITLE
✨ Feat/#172 퀴즈 관리 페이지 api 연동

### DIFF
--- a/frontend/api/axiosInstance.ts
+++ b/frontend/api/axiosInstance.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { useAuthStore } from "@/store/useAuthStore";
+import { refreshToken } from "@/api/users/refreshToken";
 
 export const axiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
@@ -15,3 +16,27 @@ axiosInstance.interceptors.request.use((config) => {
   }
   return config;
 });
+
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+    const authStore = useAuthStore.getState();
+
+    // accessToken 만료로 401이 발생한 경우
+    if (
+      error.response?.status === 401 &&
+      !originalRequest._retry // 무한 루프 방지
+    ) {
+      originalRequest._retry = true;
+      try {
+        await refreshToken();
+      } catch (refreshError) {
+        console.error("토큰 갱신 실패:", refreshError);
+        authStore.logout(); // 실패 시 로그아웃
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);

--- a/frontend/api/classes/createClass.ts
+++ b/frontend/api/classes/createClass.ts
@@ -14,7 +14,6 @@ export async function createClass({
   startDate,
   endDate,
 }: CreateClassRequest) {
-  console.log("createClass", { className, classDate, startDate, endDate });
   try {
     const response = await axiosInstance.post<
       ApiResponse<CreateClassResult | null>

--- a/frontend/api/classes/fetchQuizzesByClass.ts
+++ b/frontend/api/classes/fetchQuizzesByClass.ts
@@ -1,0 +1,21 @@
+import { axiosInstance } from "@/api/axiosInstance";
+import axios from "axios";
+import { ENDPOINTS } from "@/constants/endpoints";
+import { ApiResponse } from "@/types/apiResponseTypes";
+import { FetchQuizzesByClassResult } from "@/types/classes/fetchQuizzesByClassTypes";
+
+export async function fetchQuizzesByClass(classId: string) {
+  try {
+    const response = await axiosInstance.get<
+      ApiResponse<FetchQuizzesByClassResult[] | null>
+    >(ENDPOINTS.CLASSES.GET_QUIZZES(classId));
+    return response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error) && error.response) {
+      return error.response.data as ApiResponse<
+        FetchQuizzesByClassResult[] | null
+      >;
+    }
+    throw error;
+  }
+}

--- a/frontend/api/lectures/createLecture.ts
+++ b/frontend/api/lectures/createLecture.ts
@@ -11,13 +11,6 @@ export async function createLecture({
   startTime,
   endTime,
 }: CreateLectureRequest) {
-  console.log("createClass", {
-    lectureName,
-    lectureDate,
-    classId,
-    startTime,
-    endTime,
-  });
   try {
     const response = await axiosInstance.post<ApiResponse<null>>(
       ENDPOINTS.LECTURES.CREATE,

--- a/frontend/api/lectures/deleteLectureNote.ts
+++ b/frontend/api/lectures/deleteLectureNote.ts
@@ -1,0 +1,19 @@
+import { axiosInstance } from "@/api/axiosInstance";
+import axios from "axios";
+import { ENDPOINTS } from "@/constants/endpoints";
+import { ApiResponse } from "@/types/apiResponseTypes";
+
+export async function deleteLectureNote(lectureNoteIds: string[]) {
+  try {
+    const response = await axiosInstance.delete<ApiResponse<void>>(
+      ENDPOINTS.LECTURES.DELETE_NOTE(lectureNoteIds)
+    );
+
+    return response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error) && error.response) {
+      return error.response.data as ApiResponse<string | null>;
+    }
+    throw error;
+  }
+}

--- a/frontend/api/lectures/fetchLectureNotesByClass.ts
+++ b/frontend/api/lectures/fetchLectureNotesByClass.ts
@@ -1,0 +1,21 @@
+import { axiosInstance } from "@/api/axiosInstance";
+import axios from "axios"; // 추가
+import { ENDPOINTS } from "@/constants/endpoints";
+import { ApiResponse } from "@/types/apiResponseTypes";
+import { FetchLectureNotesByClassResult } from "@/types/lectures/fetchLectureNotesByClassTypes";
+
+export async function fetchLectureNotesByClass(classId: string) {
+  try {
+    const response = await axiosInstance.get<
+      ApiResponse<FetchLectureNotesByClassResult[]>
+    >(ENDPOINTS.LECTURES.GET_NOTE_LIST_BY_CLASS(classId));
+    return response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error) && error.response) {
+      return error.response.data as ApiResponse<
+        FetchLectureNotesByClassResult[]
+      >;
+    }
+    throw error;
+  }
+}

--- a/frontend/api/lectures/uploadLectureNote.ts
+++ b/frontend/api/lectures/uploadLectureNote.ts
@@ -1,0 +1,31 @@
+import axios from "axios";
+import { axiosInstance } from "@/api/axiosInstance";
+import { ENDPOINTS } from "@/constants/endpoints";
+import { ApiResponse } from "@/types/apiResponseTypes";
+import { UploadLectureNoteResult } from "@/types/lectures/uploadLectureNoteTypes";
+
+export async function uploadLectureNote(classId: string, files: File[]) {
+  const formData = new FormData();
+  files.forEach((file) => {
+    formData.append("file", file);
+  });
+
+  try {
+    const response = await axiosInstance.post<
+      ApiResponse<UploadLectureNoteResult | UploadLectureNoteResult[]>
+    >(ENDPOINTS.LECTURES.UPLOAD_NOTE(classId), formData, {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    });
+
+    return response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error) && error.response) {
+      return error.response.data as ApiResponse<
+        UploadLectureNoteResult | UploadLectureNoteResult[]
+      >;
+    }
+    throw error;
+  }
+}

--- a/frontend/api/quizzes/createQuiz.ts
+++ b/frontend/api/quizzes/createQuiz.ts
@@ -1,0 +1,23 @@
+import axios from "axios";
+import { axiosInstance } from "@/api/axiosInstance";
+import { ENDPOINTS } from "@/constants/endpoints";
+import { ApiResponse } from "@/types/apiResponseTypes";
+import {
+  CreateQuizRequest,
+  CreateQuizResult,
+} from "@/types/quizzes/createQuizTypes";
+
+export async function createQuiz({ lectureId, useAudio }: CreateQuizRequest) {
+  try {
+    const response = await axiosInstance.post<
+      ApiResponse<CreateQuizResult | null>
+    >(ENDPOINTS.QUIZZES.CREATE(lectureId), { useAudio });
+
+    return response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error) && error.response) {
+      return error.response.data as ApiResponse<CreateQuizResult | null>;
+    }
+    throw error;
+  }
+}

--- a/frontend/api/quizzes/recreateQuiz.ts
+++ b/frontend/api/quizzes/recreateQuiz.ts
@@ -1,0 +1,23 @@
+import axios from "axios";
+import { axiosInstance } from "@/api/axiosInstance";
+import { ENDPOINTS } from "@/constants/endpoints";
+import { ApiResponse } from "@/types/apiResponseTypes";
+import {
+  CreateQuizRequest,
+  CreateQuizResult,
+} from "@/types/quizzes/createQuizTypes";
+
+export async function recreateQuiz({ lectureId, useAudio }: CreateQuizRequest) {
+  try {
+    const response = await axiosInstance.post<
+      ApiResponse<CreateQuizResult | null>
+    >(ENDPOINTS.QUIZZES.RECREATE(lectureId), { useAudio });
+
+    return response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error) && error.response) {
+      return error.response.data as ApiResponse<CreateQuizResult | null>;
+    }
+    throw error;
+  }
+}

--- a/frontend/api/quizzes/saveQuiz.ts
+++ b/frontend/api/quizzes/saveQuiz.ts
@@ -5,12 +5,13 @@ import { ApiResponse } from "@/types/apiResponseTypes";
 import { Quiz } from "@/types/quizzes/createQuizTypes";
 import { SaveQuizRequest, SaveQuizResult } from "@/types/quizzes/saveQuizTypes";
 
-export async function saveq(lectureId: string, quizzes: Quiz[]) {
+export async function saveQuiz(lectureId: string, quizzes: Quiz[]) {
   try {
     const quizzesWithOrder = quizzes.map((quiz, idx) => ({
       ...quiz,
       quizOrder: idx + 1,
     }));
+    console.log({ quizzes: quizzesWithOrder });
 
     const response = await axiosInstance.post<ApiResponse<SaveQuizRequest>>(
       ENDPOINTS.QUIZZES.SAVE(lectureId),

--- a/frontend/api/quizzes/saveQuiz.ts
+++ b/frontend/api/quizzes/saveQuiz.ts
@@ -1,0 +1,27 @@
+import axios from "axios";
+import { axiosInstance } from "@/api/axiosInstance";
+import { ENDPOINTS } from "@/constants/endpoints";
+import { ApiResponse } from "@/types/apiResponseTypes";
+import { Quiz } from "@/types/quizzes/createQuizTypes";
+import { SaveQuizRequest, SaveQuizResult } from "@/types/quizzes/saveQuizTypes";
+
+export async function saveq(lectureId: string, quizzes: Quiz[]) {
+  try {
+    const quizzesWithOrder = quizzes.map((quiz, idx) => ({
+      ...quiz,
+      quizOrder: idx + 1,
+    }));
+
+    const response = await axiosInstance.post<ApiResponse<SaveQuizRequest>>(
+      ENDPOINTS.QUIZZES.SAVE(lectureId),
+      { quizzes: quizzesWithOrder }
+    );
+
+    return response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error) && error.response) {
+      return error.response.data as ApiResponse<SaveQuizResult>;
+    }
+    throw error;
+  }
+}

--- a/frontend/app/teacher/lecture-management/page.module.scss
+++ b/frontend/app/teacher/lecture-management/page.module.scss
@@ -7,7 +7,6 @@
   h1 {
     font-size: $font-size-xl;
     font-weight: $font-weight-bold;
-    margin-bottom: $spacing-lg;
   }
 
   // NoDataView가 있을 때는 중앙 정렬

--- a/frontend/app/teacher/lecturenote-management/page.module.scss
+++ b/frontend/app/teacher/lecturenote-management/page.module.scss
@@ -1,0 +1,47 @@
+.container {
+  padding: $spacing-xl;
+  height: calc(100vh - 80px);
+  display: flex;
+  flex-direction: column;
+
+  h1 {
+    font-size: $font-size-xl;
+    font-weight: $font-weight-bold;
+  }
+
+  // NoDataView가 있을 때는 중앙 정렬
+  :global(.noDataView) {
+    height: 100%;
+    display: flex;
+    align-items: center;
+  }
+}
+
+.addButtonContainer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.addButton {
+  font-family: $font-default;
+  padding: $spacing-sm $spacing-md;
+  background-color: $color-blue;
+  color: $color-white;
+  font-weight: $font-weight-medium;
+  border: none;
+  border-radius: $radius-md;
+  font-size: $font-size-sm;
+  cursor: pointer;
+  transition: $transition-fast;
+  font-size: $font-size-md;
+
+  &:hover {
+    background-color: $color-lightblue;
+  }
+}
+
+.lectureNoteListContainer {
+  display: flex;
+  gap: $spacing-lg;
+  height: fit-content;
+}

--- a/frontend/app/teacher/lecturenote-management/page.tsx
+++ b/frontend/app/teacher/lecturenote-management/page.tsx
@@ -19,15 +19,18 @@ export default function TeacherLectureNoteManagementPage() {
   >([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isUploading, setIsUploading] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
   // 강의자료 목록 불러오기
   const loadLectureNotes = async (classId: string) => {
+    setIsLoading(true);
     const response = await fetchLectureNotesByClass(classId);
     if (response.isSuccess && response.result) {
       setLectureNotes(response.result);
     } else {
       setLectureNotes([]);
     }
+    setIsLoading(false);
   };
 
   useEffect(() => {
@@ -91,6 +94,15 @@ export default function TeacherLectureNoteManagementPage() {
     fileInputRef.current?.click();
   };
 
+  if (isLoading) {
+    return (
+      <div className={styles.container}>
+        <h1>[{selectedClassName}] 강의자료 관리</h1>
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
   if (!selectedClassId || !selectedClassName) {
     return (
       <div className={styles.container}>
@@ -130,7 +142,7 @@ export default function TeacherLectureNoteManagementPage() {
       {isUploading && (
         <AlertModal hideButton onClose={() => setIsUploading(false)}>
           <LoadingSpinner />
-          <div style={{ marginTop: 16 }}>업로드 중입니다...</div>
+          <div>강의자료를 업로드 중입니다...</div>
         </AlertModal>
       )}
     </div>

--- a/frontend/app/teacher/lecturenote-management/page.tsx
+++ b/frontend/app/teacher/lecturenote-management/page.tsx
@@ -4,10 +4,13 @@ import styles from "./page.module.scss";
 import useSelectedClassStore from "@/store/useSelectedClassStore";
 import NoDataView from "@/components/NoDataView/NoDataView";
 import { FileText } from "lucide-react";
-import LoadingSpinner from "@/components/LoadingSpinner/LoadingSpinner";
+import { useRef, useState } from "react";
+import AlertModal from "@/components/Modal/AlertModal/AlertModal";
 
 export default function TeacherLectureNoteManagementPage() {
   const { selectedClassId, selectedClassName } = useSelectedClassStore();
+  const [alert, setAlert] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const lectureNotes = [
     {
@@ -34,6 +37,72 @@ export default function TeacherLectureNoteManagementPage() {
     console.log("Updated Lecture Notes:", updatedLectureNotes);
   };
 
+  const handleFileSelect = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    if (!selectedClassId) {
+      setAlert("클래스를 선택해주세요.");
+      return;
+    }
+
+    // 파일 크기 제한 (10MB)
+    const maxSize = 10 * 1024 * 1024;
+    if (file.size > maxSize) {
+      setAlert("파일 크기는 10MB를 초과할 수 없습니다.");
+      return;
+    }
+
+    // 파일 형식 검사
+    const allowedTypes = [
+      "application/pdf",
+      "application/msword",
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "application/vnd.ms-powerpoint",
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "application/vnd.ms-excel",
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ];
+
+    if (!allowedTypes.includes(file.type)) {
+      setAlert(
+        "지원하지 않는 파일 형식입니다. (지원 형식: PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX)"
+      );
+      return;
+    }
+
+    try {
+      // TODO: API 연동
+      // const formData = new FormData();
+      // formData.append("file", file);
+      // formData.append("classId", selectedClassId);
+
+      // const response = await createLectureNote(formData);
+
+      // if (response.isSuccess) {
+      //   // 성공 처리
+      // } else {
+      //   setAlert(response.message || "강의자료 업로드에 실패했습니다.");
+      // }
+
+      console.log("Selected file:", file);
+    } catch (error) {
+      console.error("Failed to upload lecture note:", error);
+      setAlert("강의자료 업로드 중 오류가 발생했습니다.");
+    }
+
+    // 파일 입력 초기화
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const handleAddButtonClick = () => {
+    fileInputRef.current?.click();
+  };
+
   if (!selectedClassId || !selectedClassName) {
     return (
       <div className={styles.container}>
@@ -46,20 +115,21 @@ export default function TeacherLectureNoteManagementPage() {
       </div>
     );
   }
-  // if (isLoading) {
-  //   return (
-  //     <div className={styles.container}>
-  //       <h1>[{selectedClassName}] 강의 관리</h1>
-  //       <LoadingSpinner />
-  //     </div>
-  //   );
-  // }
 
   return (
     <div className={styles.container}>
       <h1>[{selectedClassName}] 강의자료 관리</h1>
       <div className={styles.addButtonContainer}>
-        <button className={styles.addButton}>+ 강의자료 추가하기</button>
+        <input
+          type="file"
+          ref={fileInputRef}
+          onChange={handleFileSelect}
+          style={{ display: "none" }}
+          accept=".pdf,.doc,.docx,.ppt,.pptx,.xls,.xlsx"
+        />
+        <button className={styles.addButton} onClick={handleAddButtonClick}>
+          + 강의자료 추가하기
+        </button>
       </div>
       <div className={styles.lectureNoteListContainer}>
         <ManagementTable
@@ -68,6 +138,7 @@ export default function TeacherLectureNoteManagementPage() {
           onDelete={handleDelete}
         />
       </div>
+      {alert && <AlertModal onClose={() => setAlert(null)}>{alert}</AlertModal>}
     </div>
   );
 }

--- a/frontend/app/teacher/lecturenote-management/page.tsx
+++ b/frontend/app/teacher/lecturenote-management/page.tsx
@@ -1,7 +1,14 @@
 "use client";
 import ManagementTable from "@/components/ManagementTable/ManagementTable";
+import styles from "./page.module.scss";
+import useSelectedClassStore from "@/store/useSelectedClassStore";
+import NoDataView from "@/components/NoDataView/NoDataView";
+import { FileText } from "lucide-react";
+import LoadingSpinner from "@/components/LoadingSpinner/LoadingSpinner";
 
 export default function TeacherLectureNoteManagementPage() {
+  const { selectedClassId, selectedClassName } = useSelectedClassStore();
+
   const lectureNotes = [
     {
       lectureNoteId: "note1",
@@ -27,13 +34,40 @@ export default function TeacherLectureNoteManagementPage() {
     console.log("Updated Lecture Notes:", updatedLectureNotes);
   };
 
+  if (!selectedClassId || !selectedClassName) {
+    return (
+      <div className={styles.container}>
+        <h1>퀴즈 관리</h1>
+        <NoDataView
+          icon={FileText}
+          title="선택된 클래스가 없습니다"
+          description="좌상단의 클래스 선택 메뉴에서 클래스를 선택해주세요"
+        />
+      </div>
+    );
+  }
+  // if (isLoading) {
+  //   return (
+  //     <div className={styles.container}>
+  //       <h1>[{selectedClassName}] 강의 관리</h1>
+  //       <LoadingSpinner />
+  //     </div>
+  //   );
+  // }
+
   return (
-    <div style={{ padding: "20px" }}>
-      <ManagementTable
-        type="lectureNote"
-        data={lectureNotes}
-        onDelete={handleDelete}
-      />
+    <div className={styles.container}>
+      <h1>[{selectedClassName}] 강의자료 관리</h1>
+      <div className={styles.addButtonContainer}>
+        <button className={styles.addButton}>+ 강의자료 추가하기</button>
+      </div>
+      <div className={styles.lectureNoteListContainer}>
+        <ManagementTable
+          type="lectureNote"
+          data={lectureNotes}
+          onDelete={handleDelete}
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/app/teacher/lecturenote-management/page.tsx
+++ b/frontend/app/teacher/lecturenote-management/page.tsx
@@ -9,6 +9,7 @@ import AlertModal from "@/components/Modal/AlertModal/AlertModal";
 import { uploadLectureNote } from "@/api/lectures/uploadLectureNote";
 import { fetchLectureNotesByClass } from "@/api/lectures/fetchLectureNotesByClass";
 import { FetchLectureNotesByClassResult } from "@/types/lectures/fetchLectureNotesByClassTypes";
+import LoadingSpinner from "@/components/LoadingSpinner/LoadingSpinner";
 
 export default function TeacherLectureNoteManagementPage() {
   const { selectedClassId, selectedClassName } = useSelectedClassStore();
@@ -17,6 +18,7 @@ export default function TeacherLectureNoteManagementPage() {
     FetchLectureNotesByClassResult[]
   >([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isUploading, setIsUploading] = useState(false);
 
   // 강의자료 목록 불러오기
   const loadLectureNotes = async (classId: string) => {
@@ -64,6 +66,7 @@ export default function TeacherLectureNoteManagementPage() {
       validFiles.push(file);
     }
 
+    setIsUploading(true);
     try {
       const response = await uploadLectureNote(selectedClassId, validFiles);
       if (response.isSuccess) {
@@ -77,7 +80,7 @@ export default function TeacherLectureNoteManagementPage() {
     } catch {
       setAlert("강의자료 업로드 중 오류가 발생했습니다.");
     }
-
+    setIsUploading(false);
     // 파일 입력 초기화
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
@@ -124,6 +127,12 @@ export default function TeacherLectureNoteManagementPage() {
         />
       </div>
       {alert && <AlertModal onClose={() => setAlert(null)}>{alert}</AlertModal>}
+      {isUploading && (
+        <AlertModal hideButton onClose={() => setIsUploading(false)}>
+          <LoadingSpinner />
+          <div style={{ marginTop: 16 }}>업로드 중입니다...</div>
+        </AlertModal>
+      )}
     </div>
   );
 }

--- a/frontend/app/teacher/quiz-management/_components/LectureItem/LectureItem.module.scss
+++ b/frontend/app/teacher/quiz-management/_components/LectureItem/LectureItem.module.scss
@@ -66,6 +66,20 @@
         color: $color-blue;
         border: 1px solid $color-blue;
       }
+
+      &.showDashboardNotYet {
+        background-color: $color-neutral-8;
+        color: $color-neutral-6;
+        border: 1px solid $color-neutral-6;
+        &:hover {
+          transform: scale(1);
+          cursor: not-allowed;
+        }
+
+        &:active {
+          transform: scale(1);
+        }
+      }
     }
     .beforeLecture {
       color: $color-neutral-6;

--- a/frontend/app/teacher/quiz-management/_components/LectureItem/LectureItem.tsx
+++ b/frontend/app/teacher/quiz-management/_components/LectureItem/LectureItem.tsx
@@ -4,42 +4,28 @@ import { useState } from "react";
 import MakeQuizModal from "@/components/Modal/MakeQuizModal/MakeQuizModal";
 import { ROUTES } from "@/constants/routes";
 import { useRouter } from "next/navigation";
+import { FetchQuizzesByClassResult } from "@/types/classes/fetchQuizzesByClassTypes";
 
-interface LectureItemProps {
-  lectureId: string;
-  title: string;
-  lectureDate: string;
-  status: "beforeLecture" | "showDashboard" | "quizCreation";
-  startTime: string;
-  endTime: string;
-}
-
-export default function LectureItem({
-  lectureId,
-  title,
-  lectureDate,
-  status,
-  startTime,
-  endTime,
-}: LectureItemProps) {
+export default function LectureItem(lecture: FetchQuizzesByClassResult) {
   const [showQuizModal, setShowQuizModal] = useState(false);
-
   const router = useRouter();
 
-  const getActionButton = (status: LectureItemProps["status"]) => {
+  const getActionButton = (status: string) => {
     switch (status) {
       case "beforeLecture":
         return <div className={styles.beforeLecture}>강의 전</div>;
-      case "showDashboard":
+      case "checkDashboard":
         return (
           <button
             className={styles.showDashboard}
-            onClick={() => router.push(ROUTES.teacherQuizDashboard(lectureId))}
+            onClick={() =>
+              router.push(ROUTES.teacherQuizDashboard(lecture.lectureId))
+            }
           >
             대시보드 확인
           </button>
         );
-      case "quizCreation":
+      case "makeQuiz":
         return (
           <button
             className={styles.quizCreation}
@@ -55,25 +41,27 @@ export default function LectureItem({
     <>
       <div className={styles.lectureItem}>
         <div className={styles.lectureInfo}>
-          <span className={styles.title}>{title}</span>
+          <span className={styles.title}>
+            {lecture.session}. {lecture.title}
+          </span>
           <div className={styles.dateTime}>
             <div className={styles.date}>
               <Calendar size={16} />
-              <span>{lectureDate}</span>
+              <span>{`${lecture.date} (${lecture.day})`}</span>
             </div>
             <div className={styles.time}>
               <Clock size={16} />
               <span>
-                {startTime} - {endTime} AM
+                {lecture.startTime} - {lecture.endTime} AM
               </span>
             </div>
           </div>
         </div>
-        <div className={styles.action}>{getActionButton(status)}</div>
+        <div className={styles.action}>{getActionButton(lecture.status)}</div>
       </div>
       {showQuizModal && (
         <MakeQuizModal
-          lectureId={lectureId}
+          lectureId={lecture.lectureId}
           onClose={() => setShowQuizModal(false)}
         />
       )}

--- a/frontend/app/teacher/quiz-management/_components/LectureItem/LectureItem.tsx
+++ b/frontend/app/teacher/quiz-management/_components/LectureItem/LectureItem.tsx
@@ -5,6 +5,7 @@ import MakeQuizModal from "@/components/Modal/MakeQuizModal/MakeQuizModal";
 import { ROUTES } from "@/constants/routes";
 import { useRouter } from "next/navigation";
 import { FetchQuizzesByClassResult } from "@/types/classes/fetchQuizzesByClassTypes";
+import dayjs from "dayjs";
 
 export default function LectureItem(lecture: FetchQuizzesByClassResult) {
   const [showQuizModal, setShowQuizModal] = useState(false);
@@ -14,7 +15,19 @@ export default function LectureItem(lecture: FetchQuizzesByClassResult) {
     switch (status) {
       case "beforeLecture":
         return <div className={styles.beforeLecture}>강의 전</div>;
-      case "checkDashboard":
+      case "checkDashboard": {
+        const now = dayjs();
+        const lectureDate = dayjs(lecture.date, "YYYY-MM-DD");
+        const isToday = now.isSame(lectureDate, "day");
+        const midnight = lectureDate.add(1, "day").startOf("day");
+        const isBeforeMidnight = now.isBefore(midnight);
+        if (isToday && isBeforeMidnight) {
+          return (
+            <button className={styles.showDashboardNotYet} disabled>
+              오늘 밤 12:00 확인 가능
+            </button>
+          );
+        }
         return (
           <button
             className={styles.showDashboard}
@@ -25,6 +38,7 @@ export default function LectureItem(lecture: FetchQuizzesByClassResult) {
             대시보드 확인
           </button>
         );
+      }
       case "makeQuiz":
         return (
           <button
@@ -52,7 +66,7 @@ export default function LectureItem(lecture: FetchQuizzesByClassResult) {
             <div className={styles.time}>
               <Clock size={16} />
               <span>
-                {lecture.startTime} - {lecture.endTime} AM
+                {lecture.startTime} - {lecture.endTime}
               </span>
             </div>
           </div>

--- a/frontend/app/teacher/quiz-management/page.tsx
+++ b/frontend/app/teacher/quiz-management/page.tsx
@@ -6,57 +6,22 @@ import { useEffect, useState } from "react";
 import LectureItem from "./_components/LectureItem/LectureItem";
 import NoDataView from "@/components/NoDataView/NoDataView";
 import { MessageCircleQuestion } from "lucide-react";
-
-interface Lecture {
-  lectureId: string;
-  title: string;
-  lectureDate: string;
-  status: "beforeLecture" | "showDashboard" | "quizCreation";
-  startTime: string;
-  endTime: string;
-}
+import { fetchQuizzesByClass } from "@/api/classes/fetchQuizzesByClass";
+import { FetchQuizzesByClassResult } from "@/types/classes/fetchQuizzesByClassTypes";
 
 export default function TeacherQuizManagementPage() {
   const { selectedClassId, selectedClassName } = useSelectedClassStore();
-  const [lectures, setLectures] = useState<Lecture[]>([
-    {
-      lectureId: "1",
-      title: "1주차",
-      lectureDate: "2025.03.18 (화)",
-      status: "beforeLecture",
-      startTime: "10:30",
-      endTime: "11:45",
-    },
-    {
-      lectureId: "2",
-      title: "2주차",
-      lectureDate: "2025.03.18 (화)",
-      status: "showDashboard",
-      startTime: "10:30",
-      endTime: "11:45",
-    },
-    {
-      lectureId: "3",
-      title: "3주차",
-      lectureDate: "2025.03.18 (화)",
-      status: "quizCreation",
-      startTime: "10:30",
-      endTime: "11:45",
-    },
-    {
-      lectureId: "4",
-      title: "4주차",
-      lectureDate: "2025.03.18 (화)",
-      status: "beforeLecture",
-      startTime: "10:30",
-      endTime: "11:45",
-    },
-  ]);
+  const [lectures, setLectures] = useState<FetchQuizzesByClassResult[]>([]);
 
   useEffect(() => {
     if (selectedClassId) {
-      // TODO: API 호출하여 해당 클래스의 강의 목록을 가져옴
-      console.log("Selected Class ID:", selectedClassId);
+      fetchQuizzesByClass(selectedClassId).then((res) => {
+        if (res.isSuccess && res.result) {
+          setLectures(res.result);
+        } else {
+          setLectures([]);
+        }
+      });
     }
   }, [selectedClassId]);
 
@@ -64,7 +29,6 @@ export default function TeacherQuizManagementPage() {
     return (
       <div className={styles.container}>
         <h1>퀴즈 관리</h1>
-
         <NoDataView
           icon={MessageCircleQuestion}
           title="선택된 클래스가 없습니다"
@@ -79,7 +43,17 @@ export default function TeacherQuizManagementPage() {
       <h1>[{selectedClassName}] 퀴즈 관리</h1>
       <div className={styles.lectureList}>
         {lectures.map((lecture) => (
-          <LectureItem key={lecture.lectureId} {...lecture} />
+          <LectureItem
+            key={lecture.lectureId}
+            lectureId={lecture.lectureId}
+            session={lecture.session}
+            title={lecture.title}
+            date={lecture.date}
+            day={lecture.day}
+            startTime={lecture.startTime}
+            endTime={lecture.endTime}
+            status={lecture.status}
+          />
         ))}
       </div>
     </div>

--- a/frontend/app/teacher/quiz-management/page.tsx
+++ b/frontend/app/teacher/quiz-management/page.tsx
@@ -42,19 +42,17 @@ export default function TeacherQuizManagementPage() {
     <div className={styles.container}>
       <h1>[{selectedClassName}] 퀴즈 관리</h1>
       <div className={styles.lectureList}>
-        {lectures.map((lecture) => (
-          <LectureItem
-            key={lecture.lectureId}
-            lectureId={lecture.lectureId}
-            session={lecture.session}
-            title={lecture.title}
-            date={lecture.date}
-            day={lecture.day}
-            startTime={lecture.startTime}
-            endTime={lecture.endTime}
-            status={lecture.status}
+        {lectures.length === 0 ? (
+          <NoDataView
+            icon={MessageCircleQuestion}
+            title="강의가 없습니다"
+            description="퀴즈를 생성하기 전에 강의를 먼저 등록해주세요!"
           />
-        ))}
+        ) : (
+          lectures.map((lecture) => (
+            <LectureItem key={lecture.lectureId} {...lecture} />
+          ))
+        )}
       </div>
     </div>
   );

--- a/frontend/app/teacher/student-management/page.tsx
+++ b/frontend/app/teacher/student-management/page.tsx
@@ -43,7 +43,6 @@ export default function TeacherStudentManagementPage() {
     );
 
     // 이제 삭제된 학생을 반영하는 로직을 추가할 수 있습니다.
-    console.log("Updated Students:", updatedStudents);
   };
 
   return (

--- a/frontend/components/Button/SelectableButton/SelectableButton.module.scss
+++ b/frontend/components/Button/SelectableButton/SelectableButton.module.scss
@@ -9,7 +9,6 @@
   cursor: pointer;
   text-align: center;
   transition: background-color $transition-fast, transform $transition-fast;
-  margin: $spacing-xs 0;
   font-size: $font-size-sm;
   width: fit-content;
   font-family: $font-default;

--- a/frontend/components/ManagementTable/ManagementTable.tsx
+++ b/frontend/components/ManagementTable/ManagementTable.tsx
@@ -30,9 +30,7 @@ const ManagementTable: React.FC<ManagementTableProps> = ({
   const [deleteConfirmModalOpen, setDeleteConfirmModalOpen] =
     useState<boolean>(false);
 
-  useEffect(() => {
-    console.log("selectedItems", selectedItems);
-  }, [selectedItems]);
+  useEffect(() => {}, [selectedItems]);
 
   // 전체 선택 체크박스 클릭 시 모든 항목을 선택/해제
   const handleSelectAll = (isChecked: boolean) => {

--- a/frontend/components/ManagementTable/ManagementTable.tsx
+++ b/frontend/components/ManagementTable/ManagementTable.tsx
@@ -6,15 +6,9 @@ import Image from "next/image";
 import styles from "./ManagementTable.module.scss";
 import AlertModal from "../Modal/AlertModal/AlertModal";
 import ConfirmModal from "../Modal/ConfirmModal/ConfirmModal";
-
-// lectureNote 타입 정의
-type LectureNoteData = {
-  lectureNoteId: string;
-  lectureId: string;
-  session: number[];
-  lectureNoteUrl: string;
-  fileSize: string;
-};
+import { FetchLectureNotesByClassResult } from "@/types/lectures/fetchLectureNotesByClassTypes";
+import NoDataView from "../NoDataView/NoDataView";
+import { FileText } from "lucide-react";
 
 // student 타입 정의
 type StudentData = {
@@ -28,7 +22,7 @@ type StudentData = {
 
 type ManagementTableProps = {
   type: "lectureNote" | "student"; // 데이터 유형
-  data: (LectureNoteData | StudentData)[]; // lectureNote와 student에 맞는 데이터
+  data: (FetchLectureNotesByClassResult | StudentData)[]; // lectureNote와 student에 맞는 데이터
   onDelete: (index: string[]) => void; // 삭제 이벤트 처리 함수
 };
 
@@ -54,7 +48,7 @@ const ManagementTable: React.FC<ManagementTableProps> = ({
       const allSelectedItems = new Set(
         data.map((item) =>
           type === "lectureNote"
-            ? (item as LectureNoteData).lectureNoteId
+            ? (item as FetchLectureNotesByClassResult).lectureNoteId
             : (item as StudentData).userId
         )
       );
@@ -98,152 +92,185 @@ const ManagementTable: React.FC<ManagementTableProps> = ({
 
   return (
     <div className={styles.managementTable}>
-      <table>
-        <thead>
-          <tr>
-            {isEditMode && (
-              <th>
-                <button
-                  className={`${styles.selectButton} ${
-                    selectedItems.size === data.length ? styles.selected : ""
-                  }`}
-                  onClick={() =>
-                    handleSelectAll(selectedItems.size !== data.length)
-                  }
-                >
-                  <Check size={20} color="white" />
-                </button>
-              </th>
-            )}
-            {type === "lectureNote" ? (
-              <>
-                <th>차시</th>
-                <th>파일명</th>
-                <th>용량</th>
-              </>
-            ) : (
-              <>
-                <th>이름</th>
-                <th>소속</th>
-                <th>휴대전화</th>
-              </>
-            )}
-            <th className={styles.buttonContainer}>
-              {isEditMode ? (
-                <>
-                  <button
-                    className={styles.cancelButton}
-                    onClick={handleCancel}
-                  >
-                    <X size={14} color={"#606060"} />
-                    닫기
-                  </button>
-                  <button
-                    className={styles.deleteButton}
-                    onClick={() => setDeleteConfirmModalOpen(true)}
-                  >
-                    <Trash2 size={14} color={"#ea4335"} />
-                    삭제
-                  </button>
-                </>
-              ) : (
-                <Trash2
-                  className={styles.trashIcon}
-                  onClick={() => setIsEditMode(true)}
-                />
-              )}
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {data.map((item) => (
-            <tr
-              key={
-                type === "lectureNote"
-                  ? (item as LectureNoteData).lectureNoteId
-                  : (item as StudentData).userId
-              }
-              className={
-                selectedItems.has(
-                  type === "lectureNote"
-                    ? (item as LectureNoteData).lectureNoteId
-                    : (item as StudentData).userId
-                )
-                  ? styles.selectedRow
-                  : ""
-              }
-            >
+      {type === "lectureNote" && data.length === 0 ? (
+        <NoDataView
+          icon={FileText}
+          title="강의자료가 없습니다"
+          description="아직 업로드된 강의자료가 없습니다."
+        />
+      ) : (
+        <table>
+          <thead>
+            <tr>
               {isEditMode && (
-                <td>
+                <th>
                   <button
                     className={`${styles.selectButton} ${
-                      selectedItems.has(
-                        type === "lectureNote"
-                          ? (item as LectureNoteData).lectureNoteId
-                          : (item as StudentData).userId
-                      )
-                        ? styles.selected
-                        : ""
+                      selectedItems.size === data.length ? styles.selected : ""
                     }`}
                     onClick={() =>
-                      toggleSelection(
-                        type === "lectureNote"
-                          ? (item as LectureNoteData).lectureNoteId
-                          : (item as StudentData).userId
-                      )
-                    } // 버튼 클릭 시 선택/해제
+                      handleSelectAll(selectedItems.size !== data.length)
+                    }
                   >
                     <Check size={20} color="white" />
                   </button>
-                </td>
+                </th>
               )}
               {type === "lectureNote" ? (
                 <>
-                  <td>{(item as LectureNoteData).session.join(", ")}</td>
-                  <td>{(item as LectureNoteData).lectureNoteUrl}</td>
-                  <td>{(item as LectureNoteData).fileSize}</td>
-                  <td></td>
+                  <th>차시</th>
+                  <th>파일명</th>
+                  <th>용량</th>
                 </>
               ) : (
                 <>
-                  <td className={styles.profileContainer}>
-                    <Image
-                      src={
-                        (item as StudentData).profile ||
-                        "/images/default_profile.jpg"
-                      }
-                      alt={(item as StudentData).name}
-                      width={40}
-                      height={40}
-                      className={styles.profileImage}
-                    />
-                    {(item as StudentData).nickname}
-                  </td>
-                  <td>{(item as StudentData).organization}</td>
-                  <td>
-                    {(item as StudentData).phoneNumber}{" "}
-                    {!isEditMode ? (
-                      <button
-                        className={styles.copyButton}
-                        onClick={() =>
-                          handleCopyPhoneNumber(
-                            (item as StudentData).phoneNumber
-                          )
-                        }
-                      >
-                        <Copy className={styles.pasteIcon} />
-                      </button>
-                    ) : (
-                      <></>
-                    )}
-                  </td>
-                  <td></td>
+                  <th>이름</th>
+                  <th>소속</th>
+                  <th>휴대전화</th>
                 </>
               )}
+              <th className={styles.buttonContainer}>
+                {isEditMode ? (
+                  <>
+                    <button
+                      className={styles.cancelButton}
+                      onClick={handleCancel}
+                    >
+                      <X size={14} color={"#606060"} />
+                      닫기
+                    </button>
+                    <button
+                      className={styles.deleteButton}
+                      onClick={() => setDeleteConfirmModalOpen(true)}
+                    >
+                      <Trash2 size={14} color={"#ea4335"} />
+                      삭제
+                    </button>
+                  </>
+                ) : (
+                  <Trash2
+                    className={styles.trashIcon}
+                    onClick={() => setIsEditMode(true)}
+                  />
+                )}
+              </th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {data.map((item) => (
+              <tr
+                key={
+                  type === "lectureNote"
+                    ? (item as FetchLectureNotesByClassResult).lectureNoteId
+                    : (item as StudentData).userId
+                }
+                className={
+                  selectedItems.has(
+                    type === "lectureNote"
+                      ? (item as FetchLectureNotesByClassResult).lectureNoteId
+                      : (item as StudentData).userId
+                  )
+                    ? styles.selectedRow
+                    : ""
+                }
+              >
+                {isEditMode && (
+                  <td>
+                    <button
+                      className={`${styles.selectButton} ${
+                        selectedItems.has(
+                          type === "lectureNote"
+                            ? (item as FetchLectureNotesByClassResult)
+                                .lectureNoteId
+                            : (item as StudentData).userId
+                        )
+                          ? styles.selected
+                          : ""
+                      }`}
+                      onClick={() =>
+                        toggleSelection(
+                          type === "lectureNote"
+                            ? (item as FetchLectureNotesByClassResult)
+                                .lectureNoteId
+                            : (item as StudentData).userId
+                        )
+                      } // 버튼 클릭 시 선택/해제
+                    >
+                      <Check size={20} color="white" />
+                    </button>
+                  </td>
+                )}
+                {type === "lectureNote" ? (
+                  <>
+                    <td>
+                      {(item as FetchLectureNotesByClassResult).session.join(
+                        ", "
+                      )}
+                    </td>
+                    <td>
+                      <a
+                        href={
+                          (item as FetchLectureNotesByClassResult)
+                            .lectureNoteUrl
+                        }
+                        download
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{
+                          color: "#4894fe",
+                          textDecoration: "underline",
+                          cursor: "pointer",
+                        }}
+                      >
+                        {(item as FetchLectureNotesByClassResult).lectureName ||
+                          (item as FetchLectureNotesByClassResult)
+                            .lectureNoteUrl}
+                      </a>
+                    </td>
+                    <td>{(item as FetchLectureNotesByClassResult).fileSize}</td>
+                    <td></td>
+                  </>
+                ) : (
+                  <>
+                    <td className={styles.profileContainer}>
+                      <Image
+                        src={
+                          (item as StudentData).profile ||
+                          "/images/default_profile.jpg"
+                        }
+                        alt={(item as StudentData).name}
+                        width={40}
+                        height={40}
+                        className={styles.profileImage}
+                      />
+                      {(item as StudentData).nickname}
+                    </td>
+                    <td>{(item as StudentData).organization}</td>
+                    <td>
+                      {(item as StudentData).phoneNumber}{" "}
+                      {!isEditMode ? (
+                        <button
+                          className={styles.copyButton}
+                          onClick={() =>
+                            handleCopyPhoneNumber(
+                              (item as StudentData).phoneNumber
+                            )
+                          }
+                        >
+                          <Copy className={styles.pasteIcon} />
+                        </button>
+                      ) : (
+                        <></>
+                      )}
+                    </td>
+                    <td></td>
+                  </>
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
       {phoneNumberCopyAlertModalOpen && (
         <AlertModal onClose={() => setPhoneNumberCopyAlertModalOpen(false)}>
           전화번호가 복사되었습니다.

--- a/frontend/components/ManagementTable/_components/LectureNoteRow.tsx
+++ b/frontend/components/ManagementTable/_components/LectureNoteRow.tsx
@@ -1,0 +1,30 @@
+import { FetchLectureNotesByClassResult } from "@/types/lectures/fetchLectureNotesByClassTypes";
+
+interface Props {
+  item: FetchLectureNotesByClassResult;
+}
+
+const LectureNoteRow: React.FC<Props> = ({ item }) => (
+  <>
+    <td>{Array.isArray(item.session) ? item.session.join(", ") : ""}</td>
+    <td>
+      <a
+        href={item.lectureNoteUrl}
+        download
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{
+          color: "#4894fe",
+          textDecoration: "underline",
+          cursor: "pointer",
+        }}
+      >
+        {item.lectureNoteName || item.lectureNoteUrl}
+      </a>
+    </td>
+    <td>{item.fileSize}</td>
+    <td></td>
+  </>
+);
+
+export default LectureNoteRow;

--- a/frontend/components/ManagementTable/_components/StudentRow.tsx
+++ b/frontend/components/ManagementTable/_components/StudentRow.tsx
@@ -1,0 +1,54 @@
+import Image from "next/image";
+import styles from "../ManagementTable.module.scss";
+import { Copy } from "lucide-react";
+
+export type StudentData = {
+  userId: string;
+  name: string;
+  nickname: string;
+  phoneNumber: string;
+  organization?: string;
+  profile?: string;
+};
+
+interface Props {
+  item: StudentData;
+  isEditMode: boolean;
+  handleCopyPhoneNumber: (phone: string) => void;
+}
+
+const StudentRow: React.FC<Props> = ({
+  item,
+  isEditMode,
+  handleCopyPhoneNumber,
+}) => (
+  <>
+    <td className={styles.profileContainer}>
+      <Image
+        src={item.profile || "/images/default_profile.jpg"}
+        alt={item.name}
+        width={40}
+        height={40}
+        className={styles.profileImage}
+      />
+      {item.nickname}
+    </td>
+    <td>{item.organization}</td>
+    <td>
+      {item.phoneNumber}{" "}
+      {!isEditMode ? (
+        <button
+          className={styles.copyButton}
+          onClick={() =>
+            handleCopyPhoneNumber((item as StudentData).phoneNumber)
+          }
+        >
+          <Copy className={styles.pasteIcon} />
+        </button>
+      ) : null}
+    </td>
+    <td></td>
+  </>
+);
+
+export default StudentRow;

--- a/frontend/components/Modal/AlertModal/AlertModal.module.scss
+++ b/frontend/components/Modal/AlertModal/AlertModal.module.scss
@@ -4,6 +4,6 @@
 
 .modal {
   @include modal-base; // 공통 스타일
-  width: 300px;
+  min-width: 300px;
   height: fit-content;
 }

--- a/frontend/components/Modal/AlertModal/AlertModal.tsx
+++ b/frontend/components/Modal/AlertModal/AlertModal.tsx
@@ -7,9 +7,14 @@ import FullWidthButton from "@/components/Button/FullWidthButton/FullWidthButton
 type AlertModalProps = {
   onClose: () => void; // 모달을 닫을 함수
   children: React.ReactNode; // children을 받아올 수 있게 설정
+  hideButton?: boolean; // 확인 버튼 숨김 여부
 };
 
-const AlertModal: React.FC<AlertModalProps> = ({ children, onClose }) => {
+const AlertModal: React.FC<AlertModalProps> = ({
+  children,
+  onClose,
+  hideButton,
+}) => {
   const handleOverlayClick = (e: React.MouseEvent) => {
     // 클릭된 곳이 modal 내부가 아닌 경우에만 onClose 실행
     if (e.target === e.currentTarget) {
@@ -21,7 +26,9 @@ const AlertModal: React.FC<AlertModalProps> = ({ children, onClose }) => {
     <div className={styles.overlay} onClick={handleOverlayClick}>
       <div className={styles.modal}>
         <div className={styles.message}>{children}</div>
-        <FullWidthButton onClick={onClose}>확인</FullWidthButton>
+        {!hideButton && (
+          <FullWidthButton onClick={onClose}>확인</FullWidthButton>
+        )}
       </div>
     </div>,
     document.body

--- a/frontend/components/Modal/MakeQuizModal/MakeQuizModal.tsx
+++ b/frontend/components/Modal/MakeQuizModal/MakeQuizModal.tsx
@@ -1,15 +1,8 @@
 // MakeQuizModal.tsx
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import styles from "./MakeQuizModal.module.scss";
 import ClosableModal from "../ClosableModal/ClosableModal";
 import QuizPreview from "./QuizPreview/QuizPreview";
-
-interface Quiz {
-  quizBody: string;
-  solution: string;
-  choices: string[];
-  type: "객관식" | "단답형" | "OX";
-}
 
 interface MakeQuizModalProps {
   onClose: () => void;
@@ -17,70 +10,7 @@ interface MakeQuizModalProps {
 }
 
 const MakeQuizModal = ({ onClose, lectureId }: MakeQuizModalProps) => {
-  const [quizzes, setQuizzes] = useState<Quiz[] | null>(null);
   const [useAudio, setUseAudio] = useState(false);
-
-  useEffect(() => {
-    // TODO: Replace with actual data fetch using lectureId
-    setTimeout(() => {
-      setQuizzes([
-        {
-          quizBody: "오늘 내가 먹고싶은 과일은?",
-          solution: "바나나",
-          choices: ["바나나", "딸기", "참외", "수박"],
-          type: "객관식",
-        },
-        {
-          quizBody: "오늘 나는 과일이 먹고싶다",
-          solution: "O",
-          choices: [],
-          type: "OX",
-        },
-        {
-          quizBody: "오늘 내가 먹고싶은 과일은?",
-          solution: "바나나",
-          choices: [],
-          type: "단답형",
-        },
-        {
-          quizBody: "오늘 내가 먹고싶은 과일은?",
-          solution: "바나나",
-          choices: [],
-          type: "단답형",
-        },
-        {
-          quizBody: "오늘 내가 먹고싶은 과일은?",
-          solution: "바나나",
-          choices: [],
-          type: "단답형",
-        },
-        {
-          quizBody: "오늘 내가 먹고싶은 과일은?",
-          solution: "바나나",
-          choices: [],
-          type: "단답형",
-        },
-        {
-          quizBody: "오늘 내가 먹고싶은 과일은?",
-          solution: "바나나",
-          choices: [],
-          type: "단답형",
-        },
-        {
-          quizBody: "오늘 내가 먹고싶은 과일은?",
-          solution: "바나나",
-          choices: [],
-          type: "단답형",
-        },
-        {
-          quizBody: "오늘 내가 먹고싶은 과일은?",
-          solution: "바나나",
-          choices: [],
-          type: "단답형",
-        },
-      ]);
-    }, 2000);
-  }, []);
 
   const handleCustomize = () => {
     // TODO: Implement customization logic
@@ -130,9 +60,11 @@ const MakeQuizModal = ({ onClose, lectureId }: MakeQuizModalProps) => {
           </div>
         </div>
         <QuizPreview
-          quizzes={quizzes}
+          lectureId={lectureId}
+          useAudio={useAudio}
           onCustomize={handleCustomize}
           onSubmit={handleSubmit}
+          onClose={onClose}
         />
       </div>
     </ClosableModal>

--- a/frontend/components/Modal/MakeQuizModal/QuizPreview/QuizPreview.module.scss
+++ b/frontend/components/Modal/MakeQuizModal/QuizPreview/QuizPreview.module.scss
@@ -130,16 +130,14 @@
 
   .quizCardHeader {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: $spacing-sm;
     position: relative;
   }
 
   .selectButtonWrapper {
-    position: absolute;
-    top: 0;
-    right: 0;
-    z-index: 2;
+    white-space: nowrap;
+    height: fit-content;
   }
 
   .type {
@@ -148,6 +146,7 @@
     background-color: $color-skyblue;
     padding: $spacing-xs $spacing-sm;
     border-radius: $radius-full;
+    white-space: nowrap;
   }
 
   .question {
@@ -186,11 +185,15 @@
 .quizContainer {
   display: flex;
   flex-direction: column;
-  gap: $spacing-xl;
+  gap: $spacing-md;
 }
 
 .moreQuiz {
-  text-align: center;
+  display: flex;
+  gap: $spacing-xs;
+  align-items: center;
+  justify-content: end;
+
   color: $color-blue;
   cursor: pointer;
   &:hover {

--- a/frontend/components/Modal/MakeQuizModal/QuizPreview/QuizPreview.tsx
+++ b/frontend/components/Modal/MakeQuizModal/QuizPreview/QuizPreview.tsx
@@ -6,7 +6,9 @@ import Masonry from "react-masonry-css";
 import SelectableButton from "@/components/Button/SelectableButton/SelectableButton";
 import AlertModal from "@/components/Modal/AlertModal/AlertModal";
 import { createQuiz } from "@/api/quizzes/createQuiz";
+import { recreateQuiz } from "@/api/quizzes/recreateQuiz";
 import { Quiz } from "@/types/quizzes/createQuizTypes";
+import { RotateCcw } from "lucide-react";
 
 interface QuizPreviewProps {
   lectureId: string;
@@ -66,7 +68,21 @@ const QuizPreview = ({
   };
 
   const handleMoreQuiz = () => {
-    console.log("moreQuiz");
+    setQuizzes(null); // 로딩 상태
+    setError(null); // 에러 초기화
+    recreateQuiz({ lectureId, useAudio })
+      .then((res) => {
+        if (res.isSuccess && res.result && Array.isArray(res.result.quizzes)) {
+          setQuizzes(res.result.quizzes);
+        } else {
+          setQuizzes([]);
+          setError(res.message || "퀴즈 생성에 실패했습니다.");
+        }
+      })
+      .catch(() => {
+        setQuizzes([]);
+        setError("퀴즈 재생성 중 오류가 발생했습니다.");
+      });
   };
 
   return (
@@ -98,6 +114,10 @@ const QuizPreview = ({
           </div>
         ) : (
           <div className={styles.quizContainer}>
+            <div className={styles.moreQuiz} onClick={handleMoreQuiz}>
+              <p>퀴즈 재생성</p>
+              <RotateCcw size={15} />
+            </div>
             <Masonry
               breakpointCols={breakpointColumnsObj}
               className={styles.masonryGrid}
@@ -148,9 +168,6 @@ const QuizPreview = ({
                 </div>
               ))}
             </Masonry>
-            <p className={styles.moreQuiz} onClick={handleMoreQuiz}>
-              + 다른 퀴즈도 보고싶어요
-            </p>
           </div>
         )}
       </div>

--- a/frontend/components/Modal/MakeQuizModal/QuizPreview/QuizPreview.tsx
+++ b/frontend/components/Modal/MakeQuizModal/QuizPreview/QuizPreview.tsx
@@ -14,7 +14,7 @@ interface QuizPreviewProps {
   lectureId: string;
   useAudio: boolean;
   onCustomize?: () => void;
-  onSubmit?: () => void;
+  onSubmit?: (quizzes: Quiz[]) => void;
   onClose?: () => void;
 }
 
@@ -27,7 +27,7 @@ const QuizPreview = ({
 }: QuizPreviewProps) => {
   const [quizzes, setQuizzes] = useState<Quiz[] | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [selectedQuizzes, setSelectedQuizzes] = useState<number[]>([]);
+  const [selectedQuizzes, setSelectedQuizzes] = useState<Quiz[]>([]);
   const [showAlert, setShowAlert] = useState(false);
 
   useEffect(() => {
@@ -49,15 +49,18 @@ const QuizPreview = ({
   }, [lectureId, useAudio]);
 
   const toggleQuizSelection = (index: number) => {
+    if (!quizzes) return;
+    const quiz = quizzes[index];
     setSelectedQuizzes((prev) => {
-      if (prev.includes(index)) {
-        return prev.filter((i) => i !== index);
+      const exists = prev.some((q) => q === quiz);
+      if (exists) {
+        return prev.filter((q) => q !== quiz);
       } else {
         if (prev.length >= 4) {
           setShowAlert(true);
           return prev;
         }
-        return [...prev, index];
+        return [...prev, quiz];
       }
     });
   };
@@ -127,7 +130,7 @@ const QuizPreview = ({
                 <div
                   key={index}
                   className={`${styles.quizCard} ${
-                    selectedQuizzes.includes(index) ? styles.selected : ""
+                    selectedQuizzes.includes(quiz) ? styles.selected : ""
                   }`}
                   onClick={() => toggleQuizSelection(index)}
                 >
@@ -142,7 +145,7 @@ const QuizPreview = ({
                     <div className={styles.question}>{quiz.quizBody}</div>
                     <div className={styles.selectButtonWrapper}>
                       <SelectableButton
-                        selected={selectedQuizzes.includes(index)}
+                        selected={selectedQuizzes.includes(quiz)}
                         onClick={(
                           e?: React.MouseEvent<Element, MouseEvent>
                         ) => {
@@ -182,7 +185,11 @@ const QuizPreview = ({
           </button>
           <button
             className={styles.submit}
-            onClick={onSubmit}
+            onClick={() => {
+              if (onSubmit && selectedQuizzes.length > 0) {
+                onSubmit(selectedQuizzes);
+              }
+            }}
             disabled={selectedQuizzes.length === 0}
           >
             이대로 퀴즈 제출하기

--- a/frontend/components/Notification/Notification.tsx
+++ b/frontend/components/Notification/Notification.tsx
@@ -38,7 +38,6 @@ const Notification: React.FC<NotificationProps> = ({
       }
 
       if (activeTab) {
-        console.log(`활성화된 탭: ${activeTab}`);
         // TODO: activeTab을 관리하는 로직을 추가
       }
     } else if (mode === "teacher") {

--- a/frontend/constants/endpoints.ts
+++ b/frontend/constants/endpoints.ts
@@ -60,8 +60,8 @@ export const ENDPOINTS = {
       `${BASE_API}/lectures/teacher/today?date=${date}`,
 
     // 노트 관련
-    UPLOAD_NOTE: (lectureId: string) =>
-      `${BASE_API}/lectures/${lectureId}/notes`,
+    UPLOAD_NOTE: (classId: string) =>
+      `${BASE_API}/lectures/${classId}/note/upload`,
     SELECT_NOTE: (lectureId: string) =>
       `${BASE_API}/lectures/${lectureId}/notes/mapping`,
     DELETE_NOTE: (lectureId: string) =>

--- a/frontend/constants/endpoints.ts
+++ b/frontend/constants/endpoints.ts
@@ -90,6 +90,8 @@ export const ENDPOINTS = {
   // 퀴즈 관련
   QUIZZES: {
     CREATE: (lectureId: string) => `${BASE_API}/quizzes/${lectureId}/create`,
+    RECREATE: (lectureId: string) =>
+      `${BASE_API}/quizzes/${lectureId}/re-create`,
     SAVE: (lectureId: string) => `${BASE_API}/quizzes/${lectureId}`,
     UPDATE: (lectureId: string) => `${BASE_API}/quizzes/${lectureId}`,
     GET: (lectureId: string) => `${BASE_API}/quizzes/${lectureId}`,

--- a/frontend/constants/endpoints.ts
+++ b/frontend/constants/endpoints.ts
@@ -70,6 +70,8 @@ export const ENDPOINTS = {
       `${BASE_API}/lectures/${lectureId}/${lectureNoteId}`,
     GET_NOTE_LIST: (lectureId: string) =>
       `${BASE_API}/lectures/${lectureId}/notes`,
+    GET_NOTE_LIST_BY_CLASS: (classId: string) =>
+      `${BASE_API}/lectures/${classId}/class/notes`,
 
     // 녹음 관련
     SAVE_RECORDING: (lectureId: string) =>

--- a/frontend/constants/endpoints.ts
+++ b/frontend/constants/endpoints.ts
@@ -64,8 +64,8 @@ export const ENDPOINTS = {
       `${BASE_API}/lectures/${classId}/note/upload`,
     SELECT_NOTE: (lectureId: string) =>
       `${BASE_API}/lectures/${lectureId}/notes/mapping`,
-    DELETE_NOTE: (lectureId: string) =>
-      `${BASE_API}/lectures/${lectureId}/notes`,
+    DELETE_NOTE: (lectureNoteIds: string[]) =>
+      `${BASE_API}/lectures/note?keys=${lectureNoteIds.join(",")}`,
     GET_NOTE_DETAIL: (lectureId: string, lectureNoteId: string) =>
       `${BASE_API}/lectures/${lectureId}/${lectureNoteId}`,
     GET_NOTE_LIST: (lectureId: string) =>

--- a/frontend/constants/endpoints.ts
+++ b/frontend/constants/endpoints.ts
@@ -47,6 +47,7 @@ export const ENDPOINTS = {
     ENTER: (classId: string) => `${BASE_API}/classes/${classId}/enter`,
     GET_ALL_NOTES: (classId: string) => `${BASE_API}/classes/${classId}/notes`,
     GET_MY_CLASSES: `${BASE_API}/classes/teacher/myclass`,
+    GET_QUIZZES: (classId: string) => `${BASE_API}/classes/${classId}/quiz`,
   },
 
   // 강의 관련

--- a/frontend/constants/endpoints.ts
+++ b/frontend/constants/endpoints.ts
@@ -92,7 +92,7 @@ export const ENDPOINTS = {
     CREATE: (lectureId: string) => `${BASE_API}/quizzes/${lectureId}/create`,
     RECREATE: (lectureId: string) =>
       `${BASE_API}/quizzes/${lectureId}/re-create`,
-    SAVE: (lectureId: string) => `${BASE_API}/quizzes/${lectureId}`,
+    SAVE: (lectureId: string) => `${BASE_API}/quizzes/${lectureId}/save`,
     UPDATE: (lectureId: string) => `${BASE_API}/quizzes/${lectureId}`,
     GET: (lectureId: string) => `${BASE_API}/quizzes/${lectureId}`,
     SUBMIT: (lectureId: string) => `${BASE_API}/quizzes/${lectureId}/submit`,

--- a/frontend/store/useSignupStore.ts
+++ b/frontend/store/useSignupStore.ts
@@ -21,7 +21,6 @@ export const useSignupStore = create<SignupState>((set) => ({
   email: "",
   password: "",
   setField: (field, value) => {
-    console.log(`[useSignupStore] ${field} updated to`, value);
     set({ [field]: value });
   },
 }));

--- a/frontend/types/classes/fetchQuizzesByClassTypes.ts
+++ b/frontend/types/classes/fetchQuizzesByClassTypes.ts
@@ -1,0 +1,10 @@
+export interface FetchQuizzesByClassResult {
+  session: number;
+  title: string;
+  date: string;
+  day: string;
+  startTime: string;
+  endTime: string;
+  status: "beforeLecture" | "makeQuiz" | "checkDashboard";
+  lectureId: string;
+}

--- a/frontend/types/lectures/fetchLectureNotesByClassTypes.ts
+++ b/frontend/types/lectures/fetchLectureNotesByClassTypes.ts
@@ -1,0 +1,8 @@
+export interface FetchLectureNotesByClassResult {
+  lectureNoteId: string;
+  classId: string;
+  lectureNoteKey: string;
+  lectureName: string;
+  fileSize: string;
+  session: number[];
+}

--- a/frontend/types/lectures/fetchLectureNotesByClassTypes.ts
+++ b/frontend/types/lectures/fetchLectureNotesByClassTypes.ts
@@ -2,7 +2,7 @@ export interface FetchLectureNotesByClassResult {
   lectureNoteId: string;
   classId: string;
   lectureNoteUrl: string;
-  lectureName: string;
+  lectureNoteName: string;
   fileSize: string;
   session: number[];
 }

--- a/frontend/types/lectures/fetchLectureNotesByClassTypes.ts
+++ b/frontend/types/lectures/fetchLectureNotesByClassTypes.ts
@@ -1,7 +1,7 @@
 export interface FetchLectureNotesByClassResult {
   lectureNoteId: string;
   classId: string;
-  lectureNoteKey: string;
+  lectureNoteUrl: string;
   lectureName: string;
   fileSize: string;
   session: number[];

--- a/frontend/types/lectures/uploadLectureNoteTypes.ts
+++ b/frontend/types/lectures/uploadLectureNoteTypes.ts
@@ -1,0 +1,5 @@
+export interface UploadLectureNoteResult {
+  lectureId: string;
+  classId: string;
+  lectureNoteUrl: string;
+}

--- a/frontend/types/quizzes/createQuizTypes.ts
+++ b/frontend/types/quizzes/createQuizTypes.ts
@@ -1,0 +1,16 @@
+export interface CreateQuizRequest {
+  lectureId: string;
+  useAudio: boolean;
+}
+
+export type CreateQuizResult = {
+  lectureId: string;
+  quizzes: Quiz[];
+};
+
+export type Quiz = {
+  quizBody: string;
+  solution: string;
+  options?: string[];
+  type: "multipleChoice" | "shortAnswer" | "trueFalse";
+};

--- a/frontend/types/quizzes/saveQuizTypes.ts
+++ b/frontend/types/quizzes/saveQuizTypes.ts
@@ -1,0 +1,11 @@
+import { Quiz } from "./createQuizTypes";
+
+export interface SaveQuizRequest {
+  quizzes: (Quiz & { quizOrder: number })[];
+}
+
+export type SaveQuizResult = {
+  lectureId: string;
+  savedCount: number;
+  quizIds: string[];
+};


### PR DESCRIPTION
### 👀 관련 이슈

#172

### ✨ 작업한 내용


- 퀴즈 목록 불러오기
- 퀴즈 만들기
 - 퀴즈 문제 생성 api 함수 생성 + 타입 생성 + 연결하기
 - 퀴즈 문제 재생성 api 함수 생성 + 타입 생성 + 연결하기
 - 퀴즈 문제 저장 api 함수 생성 + 타입 생성 + 연결하기

### 🌀 PR Point

- 퀴즈 관리 페이지에서 퀴즈 목록 확인
- 퀴즈 만들기 + 퀴즈 재생성 + 퀴즈 저장하기

### 🍰 참고사항

1. 퀴즈 생성은 강의&강의록 맵핑이 되어있어야만 가능합니다!! 맵핑은 아직 api연동이 완료되지 않아서 포스트맨에서 해야합니다
2. 퀴즈 생성시 문제가 갑자기 바뀌어 보이는 현상이 생기는데, 이는 **개발모드여서 api 호출을 2번씩 하기 때문에 발생**하는 것입니다. -> 배포시엔 문제 없을 거니까 그냥 넘기셔도 돼요!
3. 퀴즈 커스텀은 아직입니다....
4. 퀴즈 저장 결과는 DB에서 확인하셔야 합니다
### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|   퀴즈목록   |      <img width="1710" alt="image" src="https://github.com/user-attachments/assets/90c61d7f-f9ca-4076-85ee-3a8041787642" />    |
|   퀴즈 생성하기   |   ![퀴즈 생성](https://github.com/user-attachments/assets/beca9a92-01ff-49fb-ab08-eaa8930f6378)       |
|    퀴즈 재생성  |    ![퀴즈 재생성](https://github.com/user-attachments/assets/d286a35e-07f5-4be0-93d6-da020661e965)      |
|    퀴즈 저장하기  |    ![퀴즈 저장](https://github.com/user-attachments/assets/cb450fc8-9fcb-44ee-8552-48209991dffa)      |
|  퀴즈 저장 후, 12시 전이니까 대시보드 확인 버튼 비활성화    |    <img width="1710" alt="image" src="https://github.com/user-attachments/assets/4142ddff-9460-4e78-b3c5-d22455cb885b" />      |
