### PR TITLE
:bug: Bug/#182 강의 맵핑 중복 처리

### DIFF
--- a/backend/src/main/java/org/example/backend/domain/lecture/exception/LectureErrorCode.java
+++ b/backend/src/main/java/org/example/backend/domain/lecture/exception/LectureErrorCode.java
@@ -19,7 +19,11 @@ public enum LectureErrorCode implements BaseErrorCode {
     NO_AUDIO_FILE(HttpStatus.NOT_FOUND,
             "CLASS404_4", "녹음본이 존재하지 않습니다."),
     LECTURE_NOTE_NOT_FOUND(HttpStatus.NOT_FOUND,
-                           "LECTURE404_4", "존재하지 않는 강의자료입니다.");
+                           "LECTURE404_4", "존재하지 않는 강의자료입니다."),
+
+    LECTURE_NOTE_ALREADY_MAPPED(HttpStatus.NOT_FOUND,
+                           "LECTURE404_5", "이미 맵핑된 강의록 입니다.")
+    ;
 
     private final HttpStatus status;
     private final String code;

--- a/backend/src/main/java/org/example/backend/domain/lecture/service/LectureServiceImpl.java
+++ b/backend/src/main/java/org/example/backend/domain/lecture/service/LectureServiceImpl.java
@@ -32,6 +32,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -174,6 +175,21 @@ public class LectureServiceImpl implements LectureService {
         if (notes.size() != lectureNoteIds.size()) {
             throw new LectureException(LectureErrorCode.LECTURE_NOTE_NOT_FOUND);
         }
+
+        List<LectureNoteMapping> existingMappings = lectureNoteMappingRepository.findAllByLectureId(lectureId);
+
+        Set<UUID> alreadyMappedNoteIds = existingMappings.stream()
+                .map(m -> m.getLectureNote().getId())
+                .collect(Collectors.toSet());
+
+        List<UUID> duplicates = lectureNoteIds.stream()
+                .filter(alreadyMappedNoteIds::contains)
+                .toList();
+
+        if (!duplicates.isEmpty()) {
+            throw new LectureException(LectureErrorCode.LECTURE_NOTE_ALREADY_MAPPED);
+        }
+
 
         // 3. 매핑 생성
         List<LectureNoteMapping> mappings = notes.stream()

--- a/backend/src/main/java/org/example/backend/domain/lectureNote/service/LectureNoteServiceImpl.java
+++ b/backend/src/main/java/org/example/backend/domain/lectureNote/service/LectureNoteServiceImpl.java
@@ -115,6 +115,7 @@ public class LectureNoteServiceImpl implements LectureNoteService {
                     List<Integer> sessionList = mappings.stream()
                             .map(mapping -> mapping.getLecture().getSession())
                             .filter(Objects::nonNull)
+                            .distinct()
                             .sorted()
                             .toList();
 


### PR DESCRIPTION
### 👀 관련 이슈
#182 
<!-- 관련 이슈를 적어주세요 -->

### ✨ 작업한 내용
[이미 매핑되어져 있는 강의일 때 에러처리](https://github.com/KW-ClassLog/ClassLog/commit/108cf98b551b46fda6300527d6cbc47ac04c19d9)
[sessionList 에 중복된거 1개로 반환하는 코드 추가](https://github.com/KW-ClassLog/ClassLog/pull/183/commits/4831488195b98d9cc4f2e9563118879a8629c8af)
<!-- 작업한 내용을 적어주세요 -->

### 🌀 PR Point
lecture 에서
api/lectures/{lecture_id}/notes/mapping 
같은 강의랑 강의록ID 로 2번 실행하면 2번쨰에선 이미 맵핑되어있는강의록이라고 에러 뜨게함
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항
여러개 선택했을 때 한개라도 중복이면 에러처리 했습니다.

중복된것만 에러처리하거나 result 로 반환하는거는 추후에
<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|      |          |
