### PR TITLE
✨ Feat/#181 녹음본 기반 퀴즈 생성시 녹음본 없을 경우 에러발생

### DIFF
--- a/backend/src/main/java/org/example/backend/domain/quiz/exception/QuizErrorCode.java
+++ b/backend/src/main/java/org/example/backend/domain/quiz/exception/QuizErrorCode.java
@@ -10,10 +10,11 @@ public enum QuizErrorCode implements BaseErrorCode {
 
     LECTURE_NOT_FOUND(HttpStatus.NOT_FOUND, "LECTURE404_1", "해당 강의를 찾을 수 없습니다."),
     LECTURE_NOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "LECTURE404_2", "해당 강의에 등록된 강의록을 찾을 수 없습니다."),
-    QUIZ_NOT_FOUND(HttpStatus.NOT_FOUND, "QUIZ_404_1", "해당 퀴즈를 찾을 수 없습니다."),
+    QUIZ_NOT_FOUND(HttpStatus.NOT_FOUND, "QUIZ404_1", "해당 퀴즈를 찾을 수 없습니다."),
     STUDENT_NOT_CREATE_QUIZ(HttpStatus.BAD_REQUEST, "QUIZ403_1", "강사만 퀴즈를 생성할 수 있습니다."),
     UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "QUIZ403_2", "접근 권한이 없습니다."),
     INVALID_QUIZ_TYPE(HttpStatus.BAD_REQUEST, "QUIZ400_1", "잘못된 퀴즈 유형입니다."),
+    AUDIO_NOT_FOUND(HttpStatus.NOT_FOUND, "QUIZ404_2", "녹음본 기반 퀴즈는 서비스 내에서 강의 시작 후 녹음이 완료된 경우에만 생성할 수 있습니다."),
     AI_CALL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI_500", "AI 호출 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;

--- a/backend/src/main/java/org/example/backend/domain/quiz/service/QuizServiceImpl.java
+++ b/backend/src/main/java/org/example/backend/domain/quiz/service/QuizServiceImpl.java
@@ -74,7 +74,13 @@ public class QuizServiceImpl implements QuizService {
                 .map(note -> s3Service.getPresignedUrl(note.getNoteUrl()))
                 .collect(Collectors.joining(","));
 
-        String audioUrl = s3Service.getPresignedUrl(lecture.getAudioUrl());
+        String audioUrl = null;
+        if (request.isUseAudio()) {
+            if (lecture.getAudioUrl() == null) {
+                throw new QuizException(QuizErrorCode.AUDIO_NOT_FOUND);
+            }
+            audioUrl = s3Service.getPresignedUrl(lecture.getAudioUrl());
+        }
 
         try {
             if (isReGenerate) {


### PR DESCRIPTION
### 👀 관련 이슈

#181 
<!-- 관련 이슈를 적어주세요 -->

### ✨ 작업한 내용

[강의녹음 퀴즈 생성시 DB에 저장 안 되어있으면 에러 발생](https://github.com/KW-ClassLog/ClassLog/commit/5832b044932c0ba95663d878c098bc523058f26c)

<!-- 작업한 내용을 적어주세요 -->

### 🌀 PR Point

/api/quizzes/{lecture_id}/create 확인해주세요.
body에서 useAudio를 true로 설정했을 때, lecture 테이블에 audio_url이 없으면 에러가 정상적으로 발생하는지 검토 부탁드립니다.<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

docker로 실행시켜야합니다.
실행 시키기 전에 ./gradlew clean build 한번 하고 docker 실행해주세요.
<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|      |          |
