### PR TITLE
✨ Feat/#187 퀴즈 생성 불가능 파일 예외처리

### DIFF
--- a/backend/src/main/java/org/example/backend/domain/quiz/exception/QuizErrorCode.java
+++ b/backend/src/main/java/org/example/backend/domain/quiz/exception/QuizErrorCode.java
@@ -10,10 +10,11 @@ public enum QuizErrorCode implements BaseErrorCode {
 
     LECTURE_NOT_FOUND(HttpStatus.NOT_FOUND, "LECTURE404_1", "해당 강의를 찾을 수 없습니다."),
     LECTURE_NOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "LECTURE404_2", "해당 강의에 등록된 강의록을 찾을 수 없습니다."),
-    QUIZ_NOT_FOUND(HttpStatus.NOT_FOUND, "QUIZ_404_1", "해당 퀴즈를 찾을 수 없습니다."),
+    QUIZ_NOT_FOUND(HttpStatus.NOT_FOUND, "QUIZ404_1", "해당 퀴즈를 찾을 수 없습니다."),
     STUDENT_NOT_CREATE_QUIZ(HttpStatus.BAD_REQUEST, "QUIZ403_1", "강사만 퀴즈를 생성할 수 있습니다."),
     UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "QUIZ403_2", "접근 권한이 없습니다."),
     INVALID_QUIZ_TYPE(HttpStatus.BAD_REQUEST, "QUIZ400_1", "잘못된 퀴즈 유형입니다."),
+    AUDIO_NOT_FOUND(HttpStatus.NOT_FOUND, "QUIZ404_2", "녹음본 기반 퀴즈는 서비스 내에서 강의 시작 후 녹음이 완료된 경우에만 생성할 수 있습니다."),
     AI_CALL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI_500", "AI 호출 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;

--- a/backend/src/main/java/org/example/backend/domain/quiz/exception/QuizErrorCode.java
+++ b/backend/src/main/java/org/example/backend/domain/quiz/exception/QuizErrorCode.java
@@ -14,6 +14,7 @@ public enum QuizErrorCode implements BaseErrorCode {
     STUDENT_NOT_CREATE_QUIZ(HttpStatus.BAD_REQUEST, "QUIZ403_1", "강사만 퀴즈를 생성할 수 있습니다."),
     UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "QUIZ403_2", "접근 권한이 없습니다."),
     INVALID_QUIZ_TYPE(HttpStatus.BAD_REQUEST, "QUIZ400_1", "잘못된 퀴즈 유형입니다."),
+    UNSUPPORTED_NOTE_FORMAT(HttpStatus.BAD_REQUEST, "QUIZ400_2", "강의자료는 존재하나, 퀴즈 생성은 PDF, PPTX, DOCX, HWP 형식의 자료에서만 가능합니다."),
     AUDIO_NOT_FOUND(HttpStatus.NOT_FOUND, "QUIZ404_2", "녹음본 기반 퀴즈는 서비스 내에서 강의 시작 후 녹음이 완료된 경우에만 생성할 수 있습니다."),
     AI_CALL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI_500", "AI 호출 중 오류가 발생했습니다.");
 

--- a/backend/src/main/java/org/example/backend/domain/quiz/service/QuizServiceImpl.java
+++ b/backend/src/main/java/org/example/backend/domain/quiz/service/QuizServiceImpl.java
@@ -74,7 +74,13 @@ public class QuizServiceImpl implements QuizService {
                 .map(note -> s3Service.getPresignedUrl(note.getNoteUrl()))
                 .collect(Collectors.joining(","));
 
-        String audioUrl = s3Service.getPresignedUrl(lecture.getAudioUrl());
+        String audioUrl = null;
+        if (request.isUseAudio()) {
+            if (lecture.getAudioUrl() == null) {
+                throw new QuizException(QuizErrorCode.AUDIO_NOT_FOUND);
+            }
+            audioUrl = s3Service.getPresignedUrl(lecture.getAudioUrl());
+        }
 
         try {
             if (isReGenerate) {


### PR DESCRIPTION
### 👀 관련 이슈

#187
<!-- 관련 이슈를 적어주세요 -->

### ✨ 작업한 내용

[퀴즈 생성 불가능한 파일 제외](https://github.com/KW-ClassLog/ClassLog/commit/4c1b9efec0e13e9daa4f8259dbf5785613b21103)
[퀴즈 생성 가능한 자료가 없을 경우 에러 발생](https://github.com/KW-ClassLog/ClassLog/commit/b14c22105a74a436f4040082bdd823ed6fcf890b)

<!-- 작업한 내용을 적어주세요 -->

### 🌀 PR Point

/api/quizzes/{lecture_id}/create 확인해주세요.
매핑된 강의자료가 pdf, docx, pptx, hwp 파일 외에 다른 자료만 있을 때 에러 발생 되는지 확인해주세요.
다른 파일과 퀴즈 생성 가능한 파일 둘다 매핑 되어있을 때 AI 호출 에러 발생 없이 퀴즈 생성 잘 되는지 확인해주세요.
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

docker로 실행시켜야합니다.
실행 시키기 전에 ./gradlew clean build 한번 하고 docker 실행해주세요.<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|      |          |
