### PR TITLE
:recycle: Refactor/#204 강의록 맵핑할 때 맵핑되어 있으면 유지, 삭제, 추가 되도록 수정

### DIFF
--- a/backend/src/main/java/org/example/backend/domain/lecture/service/LectureServiceImpl.java
+++ b/backend/src/main/java/org/example/backend/domain/lecture/service/LectureServiceImpl.java
@@ -187,50 +187,56 @@ public class LectureServiceImpl implements LectureService {
                 .build();
     }
 
-    //강의록 강의 맵핑
     @Transactional
-    public List<UUID> mapNotes(UUID lectureId, List<UUID> lectureNoteIds) {
+    public List<UUID> mapNotes(UUID lectureId, List<UUID> requestedNoteIds) {
         // 1. 강의 조회
         Lecture lecture = lectureRepository.findById(lectureId)
                 .orElseThrow(() -> new LectureException(LectureErrorCode.LECTURE_NOT_FOUND));
 
-        // 2. 노트 목록 조회
-        List<LectureNote> notes = lectureNoteRepository.findAllById(lectureNoteIds);
-
-        if (notes.size() != lectureNoteIds.size()) {
+        // 2. 요청한 강의자료들 존재 여부 확인
+        List<LectureNote> requestedNotes = lectureNoteRepository.findAllById(requestedNoteIds);
+        if (requestedNotes.size() != requestedNoteIds.size()) {
             throw new LectureException(LectureErrorCode.LECTURE_NOTE_NOT_FOUND);
         }
 
+        // 3. 기존 매핑 조회
         List<LectureNoteMapping> existingMappings = lectureNoteMappingRepository.findAllByLectureId(lectureId);
+        Map<UUID, LectureNoteMapping> existingMapByNoteId = existingMappings.stream()
+                .collect(Collectors.toMap(m -> m.getLectureNote().getId(), m -> m));
 
-        Set<UUID> alreadyMappedNoteIds = existingMappings.stream()
-                .map(m -> m.getLectureNote().getId())
-                .collect(Collectors.toSet());
+        Set<UUID> existingNoteIds = existingMapByNoteId.keySet();
+        Set<UUID> requestedNoteIdSet = new HashSet<>(requestedNoteIds);
 
-        List<UUID> duplicates = lectureNoteIds.stream()
-                .filter(alreadyMappedNoteIds::contains)
+        // 4. 제거 대상: 기존에 있었지만 요청에 없는 것
+        Set<UUID> toRemove = new HashSet<>(existingNoteIds);
+        toRemove.removeAll(requestedNoteIdSet);
+
+        // 5. 추가 대상: 요청에 있지만 기존에 없던 것
+        Set<UUID> toAdd = new HashSet<>(requestedNoteIdSet);
+        toAdd.removeAll(existingNoteIds);
+
+        // 6. 삭제
+        List<LectureNoteMapping> mappingsToDelete = toRemove.stream()
+                .map(existingMapByNoteId::get)
+                .toList();
+        lectureNoteMappingRepository.deleteAll(mappingsToDelete);
+
+        // 7. 추가
+        List<LectureNote> notesToAdd = requestedNotes.stream()
+                .filter(note -> toAdd.contains(note.getId()))
                 .toList();
 
-        if (!duplicates.isEmpty()) {
-            throw new LectureException(LectureErrorCode.LECTURE_NOTE_ALREADY_MAPPED);
-        }
-
-
-        // 3. 매핑 생성
-        List<LectureNoteMapping> mappings = notes.stream()
+        List<LectureNoteMapping> newMappings = notesToAdd.stream()
                 .map(note -> LectureNoteMapping.builder()
                         .lecture(lecture)
                         .lectureNote(note)
                         .build())
                 .toList();
+        lectureNoteMappingRepository.saveAll(newMappings);
 
-        // 4. 저장
-        lectureNoteMappingRepository.saveAll(mappings);
-
-        // 5. 응답용 lectureNoteId 목록 반환
-        return notes.stream()
-                .map(LectureNote::getId)
-                .toList();
+        // 8. 최종 매핑된 노트 ID 반환
+        Set<UUID> finalMappedIds = new HashSet<>(requestedNoteIdSet); // 요청된 ID가 최종 상태
+        return new ArrayList<>(finalMappedIds);
     }
 
     // 교수 날짜별 강의 조회


### PR DESCRIPTION
### 👀 관련 이슈
#204 
<!-- 관련 이슈를 적어주세요 -->

### ✨ 작업한 내용
[강의록 맵핑할 때 맵핑되어 있으면 유지, 삭제, 추가 되도록 수정](https://github.com/KW-ClassLog/ClassLog/commit/94d2b90e92281e1d8d897db139959e88eb3281f2)
<!-- 작업한 내용을 적어주세요 -->

### 🌀 PR Point
lectures 폴더 에서
api/lectures/{lecture_id}/notes/mapping api 봐주시면 됩니다.
기존에 [id1, id2, id3]이 맵핑되어 있었고, 새로운 요청으로 [id1, id2, id4]가 들어오면
        → id3은 해제, id4는 추가, id1, id2는 유지
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|      |          |
