### PR TITLE
✨ Feat/#207 사용자 프로필 조회 API 추가 및 헤더 컴포넌트에 프로필 정보 표시 기능 구현

### DIFF
--- a/frontend/api/users/getProfile.ts
+++ b/frontend/api/users/getProfile.ts
@@ -1,0 +1,19 @@
+import axios from "axios";
+import { axiosInstance } from "@/api/axiosInstance";
+import { ENDPOINTS } from "@/constants/endpoints";
+import { ApiResponse } from "@/types/apiResponseTypes";
+import { GetProfileResult } from "@/types/users/getProfileTypes";
+
+export async function getProfile() {
+  try {
+    const response = await axiosInstance.get<ApiResponse<GetProfileResult>>(
+      ENDPOINTS.USERS.GET_MY_INFO
+    );
+    return response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error) && error.response) {
+      return error.response.data as ApiResponse<GetProfileResult>;
+    }
+    throw error;
+  }
+}

--- a/frontend/components/Header/Teacher/TeacherHeader.module.scss
+++ b/frontend/components/Header/Teacher/TeacherHeader.module.scss
@@ -111,7 +111,7 @@
     .profileImage {
       width: 40px;
       height: 40px;
-      border: 1px solid $color-mutedblue;
+      border: 1px solid $color-neutral-6;
       border-radius: $radius-full;
       object-fit: cover;
     }

--- a/frontend/types/users/getProfileTypes.ts
+++ b/frontend/types/users/getProfileTypes.ts
@@ -1,0 +1,8 @@
+export type GetProfileResult = {
+  userId: string;
+  name: string;
+  organization: string;
+  phoneNumber: string;
+  profile: string;
+  role: "STUDENT" | "TEACHER";
+};


### PR DESCRIPTION
### 👀 관련 이슈

#207

### ✨ 작업한 내용

- [사용자 프로필 조회 API 추가 및 헤더 컴포넌트에 프로필 정보 표시 기능 구현](https://github.com/KW-ClassLog/ClassLog/commit/129654cf23d0fb99929b832985ab66d100dc77a0)


### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|   헤더에 프로필 띄우기   |    <img width="233" alt="image" src="https://github.com/user-attachments/assets/3f19ac9b-dbb3-4f3e-ab62-597e61b5571a" />     |
