### PR TITLE
♻️ Refactor/#209 모든 강의 목록에서 차시 보여지도록 수정

### DIFF
--- a/frontend/app/teacher/(home)/_components/LectureList/LectureItem.tsx
+++ b/frontend/app/teacher/(home)/_components/LectureList/LectureItem.tsx
@@ -12,6 +12,7 @@ export default function LectureItem({
   startTime,
   endTime,
   status,
+  session,
 }: FetchLecturesByDateResult) {
   const router = useRouter();
 
@@ -23,7 +24,9 @@ export default function LectureItem({
     <div className={styles.lectureItem} onClick={handleClick}>
       <div className={styles.lectureMain}>
         <div className={styles.lectureTitle}>
-          <span className={styles.lectureTitleText}>{lectureName}</span>
+          <span className={styles.lectureTitleText}>
+            {session}. {lectureName}
+          </span>
           <span className={styles.className}>{className}</span>
         </div>
         <div className={styles.actionButton}>

--- a/frontend/app/teacher/lecture-management/_components/LectureColumn/LectureColumn.tsx
+++ b/frontend/app/teacher/lecture-management/_components/LectureColumn/LectureColumn.tsx
@@ -42,7 +42,9 @@ const LectureColumn: React.FC<LectureColumnProps> = ({
               onClick={() => handleLectureClick(l.lectureId)}
             >
               <div className={styles.lectureHeader}>
-                <div className={styles.lectureTitle}>{l.lectureName}</div>
+                <div className={styles.lectureTitle}>
+                  {l.session}. {l.lectureName}
+                </div>
                 <div className={styles.arrowButton}>
                   <ChevronRight color="#4894fe" size={20} />
                 </div>

--- a/frontend/app/teacher/quiz-management/page.module.scss
+++ b/frontend/app/teacher/quiz-management/page.module.scss
@@ -22,6 +22,7 @@
   display: flex;
   flex-direction: column;
   gap: $spacing-lg;
+  padding-bottom: $spacing-xl;
 }
 
 .lectureItem {

--- a/frontend/types/lectures/fetchLecturesByDate.ts
+++ b/frontend/types/lectures/fetchLecturesByDate.ts
@@ -6,4 +6,5 @@ export interface FetchLecturesByDateResult {
   startTime: string;
   endTime: string;
   status: "beforeLecture" | "onLecture" | "afterLecture";
+  session: number;
 }


### PR DESCRIPTION
### 👀 관련 이슈

#209

### ✨ 작업한 내용
- [강의 제목에 세션 정보 추가](https://github.com/KW-ClassLog/ClassLog/commit/5830f41a11dd723fd7ea0658f0c70b7c81942c6c)
- [퀴즈 관리 페이지 하단 여백 추가](https://github.com/KW-ClassLog/ClassLog/commit/430716fe8c9f6af94b4a9a3e7722585c952a802c)


### 🍰 참고사항
오늘의 강의 목록은 아직 api에서 session을 보내주고 있지 않아서 숫자가 뜨지 않습니다


### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|   강의 목록   |     <img width="1451" alt="image" src="https://github.com/user-attachments/assets/c49fb70e-8284-4e9b-b599-77e288669e4e" />     |
|     오늘의 강의 목록(아직 api에서 session을 보내주고 있지 않아서 숫자가 뜨지 않습니다) |     <img width="683" alt="image" src="https://github.com/user-attachments/assets/a782f5e9-c516-44c7-bf57-47c3949c5eda" />     |
