### PR TITLE
♻️ Refactor/#219 강의 상세 페이지 수정 + 퀴즈 생성 및 미리보기

### DIFF
--- a/backend/src/main/java/org/example/backend/domain/lecture/dto/response/LectureRecordingResponseDTO.java
+++ b/backend/src/main/java/org/example/backend/domain/lecture/dto/response/LectureRecordingResponseDTO.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 @Builder
 public class LectureRecordingResponseDTO {
     private UUID lectureId;
-    private String audioKey;
+    private String audioName;
     private String audioUrl;
     private String fileSize;
 }

--- a/backend/src/main/java/org/example/backend/domain/lecture/service/LectureServiceImpl.java
+++ b/backend/src/main/java/org/example/backend/domain/lecture/service/LectureServiceImpl.java
@@ -159,9 +159,11 @@ public class LectureServiceImpl implements LectureService {
         lecture.setAudioUrl(key);
         lectureRepository.save(lecture);
 
+        String audioName = key.substring(key.lastIndexOf('/') + 1);
+
         return LectureRecordingResponseDTO.builder()
                 .lectureId(lecture.getId())
-                .audioKey(key)
+                .audioName(audioName)
                 .audioUrl(s3Service.getPresignedUrl(key))
                 .build();
     }
@@ -177,13 +179,13 @@ public class LectureServiceImpl implements LectureService {
             throw new LectureException(LectureErrorCode.NO_AUDIO_FILE);
         }
 
-        String audioUrl = s3Service.getPresignedUrl(s3Key);
+        String audioName = s3Key.substring(s3Key.lastIndexOf('/') + 1);
         String fileSize = s3Service.getFileSize(s3Key);
 
         return LectureRecordingResponseDTO.builder()
                 .lectureId(lectureId)
-                .audioKey(s3Key)
-                .audioUrl(audioUrl)
+                .audioName(s3Key)
+                .audioUrl(audioName)
                 .fileSize(fileSize)
                 .build();
     }

--- a/backend/src/main/java/org/example/backend/domain/lecture/service/LectureServiceImpl.java
+++ b/backend/src/main/java/org/example/backend/domain/lecture/service/LectureServiceImpl.java
@@ -178,14 +178,14 @@ public class LectureServiceImpl implements LectureService {
         if (s3Key == null) {
             throw new LectureException(LectureErrorCode.NO_AUDIO_FILE);
         }
-
+        String audioUrl = s3Service.getPresignedUrl(s3Key);
         String audioName = s3Key.substring(s3Key.lastIndexOf('/') + 1);
         String fileSize = s3Service.getFileSize(s3Key);
 
         return LectureRecordingResponseDTO.builder()
                 .lectureId(lectureId)
-                .audioName(s3Key)
-                .audioUrl(audioName)
+                .audioName(audioName)
+                .audioUrl(audioUrl)
                 .fileSize(fileSize)
                 .build();
     }

--- a/frontend/app/teacher/lecture-detail/[lectureId]/_components/LectureRecording/LectureRecording.module.scss
+++ b/frontend/app/teacher/lecture-detail/[lectureId]/_components/LectureRecording/LectureRecording.module.scss
@@ -32,6 +32,9 @@
 }
 
 .audioName {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   padding: $spacing-xs;
   border: 1px solid $color-neutral-7;
   border-radius: $radius-lg;

--- a/frontend/app/teacher/lecture-detail/[lectureId]/_components/LectureRecording/LectureRecording.module.scss
+++ b/frontend/app/teacher/lecture-detail/[lectureId]/_components/LectureRecording/LectureRecording.module.scss
@@ -42,7 +42,7 @@
 
 .audioPlayer {
   width: 100%;
-  height: 40px;
+  height: 50px;
   border-radius: $radius-sm;
   background: $color-white;
 }

--- a/frontend/app/teacher/lecture-detail/[lectureId]/_components/LectureRecording/LectureRecording.tsx
+++ b/frontend/app/teacher/lecture-detail/[lectureId]/_components/LectureRecording/LectureRecording.tsx
@@ -6,15 +6,11 @@ import { useEffect, useState } from "react";
 import { Download } from "lucide-react";
 import { fetchAudioFile } from "@/api/lectures/fetchAudioFile";
 import { useLectureDetail } from "../LectureDetailContext";
-
-interface Audio {
-  lectureId: string;
-  audioUrl: string;
-}
+import { FetchAudioFileResult } from "@/types/lectures/fetchAudioFileTypes";
 
 export default function LectureRecording() {
   const { lectureId } = useLectureDetail();
-  const [audio, setAudio] = useState<Audio | null>(null);
+  const [audio, setAudio] = useState<FetchAudioFileResult | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -28,7 +24,7 @@ export default function LectureRecording() {
         if (response.isSuccess && response.result) {
           setAudio({
             lectureId: response.result.lectureId,
-            audioUrl: response.result.audioUrl,
+            audioName: response.result.audioName,
           });
         } else {
           setAudio(null);
@@ -76,11 +72,11 @@ export default function LectureRecording() {
         {audio ? (
           <div className={styles.audioItem}>
             <span className={styles.audioName}>
-              <FileDisplay fileName={getFileNameFromUrl(audio.audioUrl)} />
+              <FileDisplay fileName={getFileNameFromUrl(audio.audioName)} />
               <Download />
             </span>
             <audio controls className={styles.audioPlayer}>
-              <source src={audio.audioUrl} type="audio/mpeg" />
+              <source src={audio.audioName} type="audio/mpeg" />
               브라우저가 오디오를 지원하지 않습니다.
             </audio>
           </div>

--- a/frontend/app/teacher/lecture-detail/[lectureId]/_components/QuestionList/QuestionList.tsx
+++ b/frontend/app/teacher/lecture-detail/[lectureId]/_components/QuestionList/QuestionList.tsx
@@ -19,33 +19,7 @@ export default function QuestionList() {
 
   useEffect(() => {
     // TODO: API 호출로 변경
-    setQuestions([
-      {
-        sender: "user123",
-        message: "안녕하세요!",
-        timestamp: "2025-03-31T14:22:10",
-        profileUrl: "/images/default_profile.jpg",
-      },
-      {
-        sender: "user456",
-        message: "반갑습니다 :)",
-        timestamp: "2025-03-31T14:22:15",
-        profileUrl: "/images/default_profile.jpg",
-      },
-      {
-        sender: "student789",
-        message:
-          "강의 내용이 잘 이해되지 않아서 질문드립니다. 프로세스 스케줄링에 대해 더 자세히 설명해주실 수 있나요?",
-        timestamp: "2025-03-31T14:25:30",
-        profileUrl: "/images/default_profile.jpg",
-      },
-      {
-        sender: "user123",
-        message: "네, 좋은 질문이네요!",
-        timestamp: "2025-03-31T14:26:45",
-        profileUrl: "/images/default_profile.jpg",
-      },
-    ]);
+    setQuestions([]);
     setLoading(false);
   }, [lectureId]);
 

--- a/frontend/components/Button/QuizChoiceButton/QuizChoiceButton.tsx
+++ b/frontend/components/Button/QuizChoiceButton/QuizChoiceButton.tsx
@@ -22,7 +22,7 @@ type TeacherModeProps = {
   mode: "teacher";
   label: string;
   correctAnswer: string; // 정답
-  count: number; // 선택한 사람 수
+  count?: number; // 선택한 사람 수
 };
 
 type QuizChoiceButtonProps = QuizModeProps | ResultModeProps | TeacherModeProps;

--- a/frontend/components/Input/QuizInput/QuizInput.tsx
+++ b/frontend/components/Input/QuizInput/QuizInput.tsx
@@ -60,7 +60,9 @@ const QuizInput: React.FC<QuizInputProps> = (props) => {
         return props.userAnswer;
       }
     } else if (isTeacherMode(props)) {
-      return `정답 : ${props.correctAnswer} (${props.count}명)`;
+      return `정답 : ${props.correctAnswer} ${
+        props.count ? `(${props.count}명)` : ""
+      }`;
     } else if (isQuizMode(props)) {
       return props.value;
     }

--- a/frontend/components/Input/QuizInput/QuizInput.tsx
+++ b/frontend/components/Input/QuizInput/QuizInput.tsx
@@ -20,7 +20,7 @@ type ResultModeProps = {
 type TeacherModeProps = {
   mode: "teacher";
   correctAnswer: string; // 정답
-  count: number; // 선택한 사람 수
+  count?: number; // 선택한 사람 수
 };
 
 type QuizInputProps = QuizModeProps | ResultModeProps | TeacherModeProps;

--- a/frontend/components/Modal/FileSelectModal/FileSelectModal.tsx
+++ b/frontend/components/Modal/FileSelectModal/FileSelectModal.tsx
@@ -6,6 +6,7 @@ import ClosableModal from "../ClosableModal/ClosableModal";
 import FullWidthButton from "@/components/Button/FullWidthButton/FullWidthButton";
 import FileDisplay from "@/components/FileDisplay/FileDisplay";
 import SelectableButton from "@/components/Button/SelectableButton/SelectableButton";
+import LoadingSpinner from "@/components/LoadingSpinner/LoadingSpinner";
 import { X } from "lucide-react";
 import { fetchLectureNotesByClass } from "@/api/lectures/fetchLectureNotesByClass";
 import { FetchLectureNotesByClassResult } from "@/types/lectures/fetchLectureNotesByClassTypes";
@@ -194,7 +195,7 @@ const FileSelectModal: React.FC<FileSelectModalProps> = ({
         {/* 파일 목록 */}
         <div className={styles.fileList}>
           {isLoading ? (
-            <div className={styles.loading}>파일 목록을 불러오는 중...</div>
+            <LoadingSpinner text="해당 클래스에 등록된 파일 목록을 불러오는 중..." />
           ) : fileList.length === 0 ? (
             <div className={styles.emptyState}>
               업로드된 강의자료가 없습니다.

--- a/frontend/components/Modal/MakeQuizModal/CustomizeQuizModal/CustomizeQuizModal.module.scss
+++ b/frontend/components/Modal/MakeQuizModal/CustomizeQuizModal/CustomizeQuizModal.module.scss
@@ -37,6 +37,115 @@
   height: 100%;
 }
 
+.makingQuizBox {
+  background: $color-neutral-8;
+  border-radius: $radius-md;
+  padding: $spacing-md;
+  border: 1px solid $color-neutral-6;
+  height: 100%;
+}
+
+.userCreatedSection {
+  margin-top: $spacing-lg;
+  padding-top: $spacing-lg;
+  border-top: 1px solid $color-neutral-6;
+}
+
+.sectionTitle {
+  font-size: $font-size-lg;
+  font-weight: $font-weight-bold;
+  margin-bottom: $spacing-md;
+}
+
+.quizHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: $spacing-md;
+}
+
+.typeSelector {
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+}
+
+.typeBtn {
+  border: 1px solid $color-neutral-6;
+  background: $color-white;
+  border-radius: $radius-full;
+  padding: $spacing-xs $spacing-sm;
+  font-size: $font-size-sm;
+  cursor: pointer;
+  color: $color-neutral-5;
+  transition: all 0.2s;
+  font-weight: $font-weight-medium;
+  font-family: $font-default;
+
+  &:hover {
+    border-color: $color-blue;
+    color: $color-blue;
+  }
+
+  &.selected {
+    border: 2px solid $color-blue;
+    color: $color-blue;
+    font-weight: bold;
+    background: $color-skyblue;
+  }
+}
+
+.removeBtn {
+  background: $color-danger;
+  color: white;
+  border: none;
+  border-radius: $radius-sm;
+  padding: $spacing-xs $spacing-sm;
+  font-size: $font-size-sm;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-weight: $font-weight-medium;
+
+  &:hover {
+    background: darken($color-danger, 10%);
+    transform: scale(1.05);
+  }
+
+  &:active {
+    transform: scale(0.95);
+  }
+}
+
+.addQuizSection {
+  display: flex;
+  justify-content: center;
+  margin: $spacing-lg 0;
+}
+
+.addQuizBtn {
+  background: $color-blue;
+  color: white;
+  border: none;
+  border-radius: $radius-lg;
+  padding: $spacing-sm $spacing-lg;
+  font-size: $font-size-md;
+  font-weight: $font-weight-medium;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: $spacing-xs;
+
+  &:hover {
+    background: $color-lightblue;
+    transform: scale(1.02);
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+}
+
 .typeLabel {
   color: $color-blue;
   background: $color-white;

--- a/frontend/components/Modal/MakeQuizModal/CustomizeQuizModal/CustomizeQuizModal.tsx
+++ b/frontend/components/Modal/MakeQuizModal/CustomizeQuizModal/CustomizeQuizModal.tsx
@@ -277,7 +277,8 @@ const CustomizeQuizModal = ({
       <div className={styles.wrapper}>
         <h2 className={styles.title}>퀴즈 커스터마이징</h2>
         <p className={styles.description}>
-          퀴즈를 커스터마이징하여 수업에 적합한 퀴즈를 만들어보세요.
+          선택한 퀴즈를 수정하거나, 새로운 퀴즈를 직접 작성해보세요. <br />
+          수업에 딱 맞는 퀴즈로 바꿀 수 있어요!
         </p>
 
         {/* 기존 퀴즈 목록 */}
@@ -412,7 +413,7 @@ const CustomizeQuizModal = ({
           )}
           <div className={styles.addQuizSection}>
             <FitContentButton onClick={handleAddQuiz}>
-              + 퀴즈 직접 입력
+              + 새로운 퀴즈 작성
             </FitContentButton>
           </div>
         </div>
@@ -426,7 +427,7 @@ const CustomizeQuizModal = ({
             className={styles.submitButton}
             disabled={isSaving || !isAllQuizzesValid()}
           >
-            퀴즈 제출하기
+            제출 전 미리보기
           </button>
         </div>
       </div>

--- a/frontend/components/Modal/MakeQuizModal/CustomizeQuizModal/CustomizeQuizModal.tsx
+++ b/frontend/components/Modal/MakeQuizModal/CustomizeQuizModal/CustomizeQuizModal.tsx
@@ -9,6 +9,9 @@ import { useQuizStore } from "@/store/useQuizStore";
 import { saveQuiz } from "@/api/quizzes/saveQuiz";
 import AlertModal from "@/components/Modal/AlertModal/AlertModal";
 import LoadingSpinner from "@/components/LoadingSpinner/LoadingSpinner";
+import FitContentButton from "@/components/Button/FitContentButton/FitContentButton";
+import { X } from "lucide-react";
+import IconButton from "@/components/Button/IconButton/IconButton";
 
 interface CustomizeQuizModalProps {
   quizzes: Quiz[];
@@ -23,7 +26,24 @@ const CustomizeQuizModal = ({
   onGoBack,
   lectureId,
 }: CustomizeQuizModalProps) => {
-  const [editedQuizzes, setEditedQuizzes] = useState<Quiz[]>(quizzes);
+  // 기존 퀴즈의 객관식 정답을 선택지 번호로 변환
+  const processedQuizzes = quizzes.map((quiz) => {
+    if (quiz.type === "multipleChoice" && quiz.options && quiz.solution) {
+      const solutionIndex = quiz.options.findIndex(
+        (option) => option === quiz.solution
+      );
+      if (solutionIndex !== -1) {
+        return {
+          ...quiz,
+          solution: (solutionIndex + 1).toString(),
+        };
+      }
+    }
+    return quiz;
+  });
+
+  const [editedQuizzes, setEditedQuizzes] = useState<Quiz[]>(processedQuizzes);
+  const [userCreatedQuizzes, setUserCreatedQuizzes] = useState<Quiz[]>([]);
   const {
     resetLectureQuizzes,
     isSaving,
@@ -38,6 +58,85 @@ const CustomizeQuizModal = ({
     setEditedQuizzes((prev) =>
       prev.map((quiz, i) => (i === idx ? { ...quiz, [field]: value } : quiz))
     );
+  };
+
+  const handleUserQuizChange = (idx: number, field: string, value: string) => {
+    setUserCreatedQuizzes((prev) =>
+      prev.map((quiz, i) => (i === idx ? { ...quiz, [field]: value } : quiz))
+    );
+  };
+
+  const handleAddQuiz = () => {
+    const newQuiz: Quiz = {
+      quizBody: "",
+      solution: "",
+      type: "multipleChoice",
+      options: ["", "", "", ""],
+    };
+    setUserCreatedQuizzes((prev) => [...prev, newQuiz]);
+  };
+
+  const handleRemoveUserQuiz = (idx: number) => {
+    setUserCreatedQuizzes((prev) => prev.filter((_, i) => i !== idx));
+  };
+
+  const handleUserQuizTypeChange = (
+    idx: number,
+    type: "multipleChoice" | "shortAnswer" | "trueFalse"
+  ) => {
+    setUserCreatedQuizzes((prev) =>
+      prev.map((quiz, i) => {
+        if (i === idx) {
+          const newQuiz = { ...quiz, type };
+          if (type === "multipleChoice") {
+            newQuiz.options = ["", "", "", ""];
+            newQuiz.solution = "";
+          } else if (type === "shortAnswer") {
+            newQuiz.options = undefined;
+            newQuiz.solution = "";
+          } else if (type === "trueFalse") {
+            newQuiz.options = undefined;
+            newQuiz.solution = "";
+          }
+          return newQuiz;
+        }
+        return quiz;
+      })
+    );
+  };
+
+  const handleUserQuizOptionChange = (
+    quizIdx: number,
+    optionIdx: number,
+    value: string
+  ) => {
+    setUserCreatedQuizzes((prev) =>
+      prev.map((quiz, i) => {
+        if (i === quizIdx && quiz.options) {
+          const newOptions = [...quiz.options];
+          newOptions[optionIdx] = value;
+          return { ...quiz, options: newOptions };
+        }
+        return quiz;
+      })
+    );
+  };
+
+  const isQuizValid = (quiz: Quiz): boolean => {
+    if (!quiz.quizBody.trim() || !quiz.solution.trim()) {
+      return false;
+    }
+
+    if (quiz.type === "multipleChoice" && quiz.options) {
+      return quiz.options.every((option) => option.trim() !== "");
+    }
+
+    return true;
+  };
+
+  const isAllQuizzesValid = (): boolean => {
+    const allQuizzes = [...editedQuizzes, ...userCreatedQuizzes];
+    return allQuizzes.every((quiz) => isQuizValid(quiz));
   };
 
   const handleClose = () => {
@@ -56,7 +155,27 @@ const CustomizeQuizModal = ({
     setSaveSuccess(false);
     setSaveError(null);
     try {
-      const res = await saveQuiz(lectureId, editedQuizzes);
+      const allQuizzes = [...editedQuizzes, ...userCreatedQuizzes];
+
+      // 객관식 퀴즈의 정답을 선택지 번호에서 선택지 텍스트로 변환
+      const processedQuizzes = allQuizzes.map((quiz) => {
+        if (quiz.type === "multipleChoice" && quiz.options && quiz.solution) {
+          const solutionNumber = parseInt(quiz.solution);
+          if (
+            !isNaN(solutionNumber) &&
+            solutionNumber >= 1 &&
+            solutionNumber <= quiz.options.length
+          ) {
+            return {
+              ...quiz,
+              solution: quiz.options[solutionNumber - 1],
+            };
+          }
+        }
+        return quiz;
+      });
+
+      const res = await saveQuiz(lectureId, processedQuizzes);
       if (res && res.isSuccess) {
         setSaveSuccess(true);
       } else {
@@ -69,7 +188,11 @@ const CustomizeQuizModal = ({
     }
   };
 
-  const renderOXAnswer = (quiz: Quiz, idx: number) => (
+  const renderOXAnswer = (
+    quiz: Quiz,
+    idx: number,
+    isUserCreated: boolean = false
+  ) => (
     <div className={styles.answerRow}>
       <span className={styles.label}>정답 :</span>
       {["O", "X"].map((ox) => (
@@ -79,7 +202,11 @@ const CustomizeQuizModal = ({
           className={`${styles.answerBtn} ${
             quiz.solution === ox ? styles.selected : ""
           }`}
-          onClick={() => handleQuizChange(idx, "solution", ox)}
+          onClick={() =>
+            isUserCreated
+              ? handleUserQuizChange(idx, "solution", ox)
+              : handleQuizChange(idx, "solution", ox)
+          }
         >
           {ox}
         </button>
@@ -87,12 +214,16 @@ const CustomizeQuizModal = ({
     </div>
   );
 
-  const renderMultipleChoiceAnswer = (quiz: Quiz, idx: number) => (
+  const renderMultipleChoiceAnswer = (
+    quiz: Quiz,
+    idx: number,
+    isUserCreated: boolean = false
+  ) => (
     <div className={styles.answerRow}>
       <span className={styles.label}>정답 :</span>
       {quiz.options?.map((option, oIdx) => {
         const optionNumber = oIdx + 1;
-        const isSelected = quiz.solution === option;
+        const isSelected = quiz.solution === optionNumber.toString();
 
         return (
           <button
@@ -101,12 +232,43 @@ const CustomizeQuizModal = ({
             className={`${styles.answerBtn} ${
               isSelected ? styles.selected : ""
             }`}
-            onClick={() => handleQuizChange(idx, "solution", option)}
+            onClick={() =>
+              isUserCreated
+                ? handleUserQuizChange(idx, "solution", optionNumber.toString())
+                : handleQuizChange(idx, "solution", optionNumber.toString())
+            }
           >
             {optionNumber}
           </button>
         );
       })}
+    </div>
+  );
+
+  const renderQuizTypeSelector = (quiz: Quiz, idx: number) => (
+    <div className={styles.typeSelector}>
+      <span className={styles.label}>퀴즈 타입 :</span>
+      {[
+        { value: "multipleChoice", label: "객관식" },
+        { value: "shortAnswer", label: "단답형" },
+        { value: "trueFalse", label: "O/X" },
+      ].map((type) => (
+        <button
+          key={type.value}
+          type="button"
+          className={`${styles.typeBtn} ${
+            quiz.type === type.value ? styles.selected : ""
+          }`}
+          onClick={() =>
+            handleUserQuizTypeChange(
+              idx,
+              type.value as "multipleChoice" | "shortAnswer" | "trueFalse"
+            )
+          }
+        >
+          {type.label}
+        </button>
+      ))}
     </div>
   );
 
@@ -117,9 +279,11 @@ const CustomizeQuizModal = ({
         <p className={styles.description}>
           퀴즈를 커스터마이징하여 수업에 적합한 퀴즈를 만들어보세요.
         </p>
+
+        {/* 기존 퀴즈 목록 */}
         <div className={styles.quizList}>
           {editedQuizzes.map((quiz, idx) => (
-            <div key={idx} className={styles.quizBox}>
+            <div key={`edited-${idx}`} className={styles.quizBox}>
               <div className={styles.labelRow}>
                 <div className={styles.typeLabel}>
                   {quiz.type === "multipleChoice"
@@ -175,6 +339,82 @@ const CustomizeQuizModal = ({
                 renderMultipleChoiceAnswer(quiz, idx)}
             </div>
           ))}
+
+          {userCreatedQuizzes.length > 0 && (
+            <div className={styles.userCreatedSection}>
+              <h3 className={styles.sectionTitle}>직접 만든 퀴즈</h3>
+              <div className={styles.quizList}>
+                {userCreatedQuizzes.map((quiz, idx) => (
+                  <div key={`user-${idx}`} className={styles.makingQuizBox}>
+                    <div className={styles.quizHeader}>
+                      {renderQuizTypeSelector(quiz, idx)}
+                      <IconButton
+                        icon={<X />}
+                        onClick={() => handleRemoveUserQuiz(idx)}
+                        ariaLabel="퀴즈 삭제"
+                      />
+                    </div>
+                    <div className={styles.labelRow}>
+                      <BasicInput
+                        value={quiz.quizBody}
+                        onChange={(e) =>
+                          handleUserQuizChange(idx, "quizBody", e.target.value)
+                        }
+                        placeholder="문제를 입력하세요"
+                      />
+                    </div>
+                    {quiz.type === "multipleChoice" && quiz.options && (
+                      <div className={styles.options}>
+                        {quiz.options.map((option, oIdx) => (
+                          <div key={oIdx} className={styles.optionRow}>
+                            <span className={styles.optionNumber}>
+                              {oIdx + 1}
+                            </span>
+                            <BasicInput
+                              value={option}
+                              onChange={(e) =>
+                                handleUserQuizOptionChange(
+                                  idx,
+                                  oIdx,
+                                  e.target.value
+                                )
+                              }
+                              placeholder={`선택지 ${oIdx + 1}`}
+                            />
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                    {quiz.type === "shortAnswer" && (
+                      <div className={styles.labelRow}>
+                        <span className={styles.label}>정답 :</span>
+                        <BasicInput
+                          value={quiz.solution}
+                          onChange={(e) =>
+                            handleUserQuizChange(
+                              idx,
+                              "solution",
+                              e.target.value
+                            )
+                          }
+                          placeholder="정답을 입력하세요"
+                        />
+                      </div>
+                    )}
+                    {quiz.type === "trueFalse" &&
+                      renderOXAnswer(quiz, idx, true)}
+                    {quiz.type === "multipleChoice" &&
+                      renderMultipleChoiceAnswer(quiz, idx, true)}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+          <div className={styles.addQuizSection}>
+            <FitContentButton onClick={handleAddQuiz}>
+              + 퀴즈 직접 입력
+            </FitContentButton>
+          </div>
         </div>
 
         <div className={styles.buttonSection}>
@@ -184,7 +424,7 @@ const CustomizeQuizModal = ({
           <button
             onClick={handleSubmit}
             className={styles.submitButton}
-            disabled={isSaving}
+            disabled={isSaving || !isAllQuizzesValid()}
           >
             퀴즈 제출하기
           </button>

--- a/frontend/components/Modal/MakeQuizModal/QuizPreview/QuizPreview.module.scss
+++ b/frontend/components/Modal/MakeQuizModal/QuizPreview/QuizPreview.module.scss
@@ -197,3 +197,162 @@
     text-decoration: underline;
   }
 }
+
+// 미리보기 모달 스타일
+.previewWrapper {
+  display: flex;
+  flex-direction: column;
+  width: 800px;
+  max-height: 80vh;
+  transition: $transition-fast;
+  @include respond-to(md) {
+    max-width: 100%;
+  }
+  gap: $spacing-sm;
+  overflow: hidden;
+}
+
+.previewTitle {
+  font-size: $font-size-xl;
+  font-weight: bold;
+  color: $color-blue;
+}
+
+.previewDescription {
+  font-size: $font-size-md;
+  color: $color-neutral-5;
+  padding-bottom: $spacing-md;
+  border-bottom: 1px solid $color-neutral-6;
+}
+
+.previewQuizList {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-md;
+  overflow: auto;
+  max-height: 60vh;
+  padding-right: $spacing-sm;
+}
+
+.previewQuizBox {
+  background: $color-skyblue;
+  border-radius: $radius-md;
+  padding: $spacing-md;
+  border: 1px solid $color-neutral-6;
+}
+
+.previewQuizHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: $spacing-md;
+}
+
+.previewTypeLabel {
+  color: $color-blue;
+  background: $color-white;
+  border-radius: $radius-full;
+  padding: $spacing-xs $spacing-sm;
+  font-weight: bold;
+  display: inline-block;
+  font-size: $font-size-md;
+  width: fit-content;
+  white-space: nowrap;
+  border: 1px solid $color-blue;
+}
+
+.previewQuestion {
+  font-size: $font-size-md;
+  font-weight: $font-weight-medium;
+  color: $color-neutral-2;
+  margin-bottom: $spacing-md;
+  line-height: 1.5;
+}
+
+.previewOptions {
+  margin-bottom: $spacing-md;
+}
+
+.previewOption {
+  padding: $spacing-xs $spacing-sm;
+  margin-bottom: $spacing-xs;
+  background: $color-white;
+  border-radius: $radius-sm;
+  border: 1px solid $color-neutral-6;
+  font-size: $font-size-sm;
+  color: $color-neutral-3;
+}
+
+.previewAnswer {
+  font-size: $font-size-md;
+  font-weight: $font-weight-bold;
+  color: $color-blue;
+  padding: $spacing-sm;
+  background: $color-white;
+  border-radius: $radius-sm;
+  border: 1px solid $color-blue;
+}
+
+.previewButtonSection {
+  margin-top: auto;
+  border-top: 1px solid $color-neutral-6;
+  padding: $spacing-sm 0;
+  display: flex;
+  justify-content: center;
+  gap: $spacing-md;
+  background: white;
+
+  button {
+    padding: $spacing-sm $spacing-lg;
+    font-weight: $font-weight-medium;
+    @include common-input-button-style;
+    border-radius: $radius-lg;
+    border: none;
+    cursor: pointer;
+    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+
+    &:disabled {
+      background-color: $color-neutral-7;
+      color: $color-neutral-5;
+      border-color: $color-neutral-6;
+      cursor: not-allowed;
+      transform: none;
+
+      &:hover {
+        transform: none;
+      }
+    }
+
+    &:not(:disabled) {
+      &:hover {
+        transform: scale(1.02);
+      }
+
+      &:active {
+        transform: scale(0.98);
+      }
+    }
+
+    &.previewSubmitButton {
+      background-color: $color-blue;
+      color: white;
+
+      &:disabled {
+        background-color: $color-neutral-7;
+        color: $color-neutral-5;
+      }
+    }
+
+    &.previewCancelButton {
+      background-color: $color-skyblue;
+      color: $color-blue;
+      border: 1px solid $color-blue;
+
+      &:disabled {
+        background-color: $color-neutral-8;
+        color: $color-neutral-5;
+        border-color: $color-neutral-6;
+      }
+    }
+  }
+}

--- a/frontend/components/Modal/MakeQuizModal/QuizPreview/QuizPreview.module.scss
+++ b/frontend/components/Modal/MakeQuizModal/QuizPreview/QuizPreview.module.scss
@@ -124,6 +124,14 @@
     align-items: flex-start;
     gap: $spacing-sm;
     position: relative;
+    justify-content: space-between;
+  }
+
+  .quizCardHeaderContent {
+    display: flex;
+    align-items: center;
+    gap: $spacing-sm;
+    position: relative;
   }
 
   .selectButtonWrapper {

--- a/frontend/components/Modal/MakeQuizModal/QuizPreview/QuizPreview.tsx
+++ b/frontend/components/Modal/MakeQuizModal/QuizPreview/QuizPreview.tsx
@@ -218,7 +218,7 @@ const QuizPreview = ({
             }}
             disabled={selectedQuizzes.length === 0}
           >
-            이대로 퀴즈 제출하기
+            제출 전 미리보기
           </button>
         </div>
       )}

--- a/frontend/components/Modal/MakeQuizModal/QuizPreview/QuizPreview.tsx
+++ b/frontend/components/Modal/MakeQuizModal/QuizPreview/QuizPreview.tsx
@@ -10,6 +10,7 @@ import { createQuiz } from "@/api/quizzes/createQuiz";
 import { recreateQuiz } from "@/api/quizzes/recreateQuiz";
 import { Quiz } from "@/types/quizzes/createQuizTypes";
 import { useQuizStore } from "@/store/useQuizStore";
+import QuizPreviewModal from "../QuizPreviewModal/QuizPreviewModal";
 
 interface QuizPreviewProps {
   lectureId: string;
@@ -42,6 +43,7 @@ const QuizPreview = ({
   } = useQuizStore();
 
   const [showAlert, setShowAlert] = useState(false);
+  const [showPreviewModal, setShowPreviewModal] = useState(false);
 
   // 현재 lectureId의 퀴즈 가져오기
   const quizzes = getQuizzes(lectureId);
@@ -111,118 +113,140 @@ const QuizPreview = ({
       });
   };
 
-  return (
-    <div className={styles.wrapper}>
-      {error && (
-        <AlertModal
-          onClose={() => {
-            setError(null);
-            if (onClose) onClose();
-          }}
-        >
-          {error}
-        </AlertModal>
-      )}
-      {showAlert && (
-        <AlertModal onClose={() => setShowAlert(false)}>
-          최대 4개의 퀴즈만 선택할 수 있습니다.
-        </AlertModal>
-      )}
-      <div className={styles.content}>
-        {isLoading ? (
-          <div className={styles.loading}>
-            <LoadingSpinner
-              text={["AI가 퀴즈를 만들고 있어요", "잠시만 기다려주세요!"]}
-            />
-          </div>
-        ) : (
-          <div className={styles.quizContainer}>
-            <Masonry
-              breakpointCols={breakpointColumnsObj}
-              className={styles.masonryGrid}
-              columnClassName={styles.masonryColumn}
-            >
-              {quizzes?.map((quiz, index) => (
-                <div
-                  key={index}
-                  className={`${styles.quizCard} ${
-                    selectedQuizzes.includes(quiz) ? styles.selected : ""
-                  }`}
-                  onClick={() => handleQuizSelection(index)}
-                >
-                  <div className={styles.quizCardHeader}>
-                    <div className={styles.quizCardHeaderContent}>
-                      <div className={styles.type}>
-                        {quiz.type === "multipleChoice"
-                          ? "객관식"
-                          : quiz.type === "shortAnswer"
-                          ? "단답형"
-                          : "O/X"}
-                      </div>
-                      <div className={styles.question}>{quiz.quizBody}</div>
-                    </div>
+  const handlePreview = () => {
+    setShowPreviewModal(true);
+  };
 
-                    <div className={styles.selectButtonWrapper}>
-                      <SelectableButton
-                        selected={selectedQuizzes.includes(quiz)}
-                        onClick={(
-                          e?: React.MouseEvent<Element, MouseEvent>
-                        ) => {
-                          e?.stopPropagation();
-                          handleQuizSelection(index);
-                        }}
-                        disabled={false}
-                      />
-                    </div>
-                  </div>
-                  {quiz.type === "multipleChoice" &&
-                    quiz.options &&
-                    quiz.options.length > 0 && (
-                      <ul className={styles.choices}>
-                        {quiz.options.map((option, index) => (
-                          <li key={index}>
-                            {index + 1}. {option}
-                          </li>
-                        ))}
-                      </ul>
-                    )}
-                  <div className={styles.answer}>정답: {quiz.solution}</div>
-                </div>
-              ))}
-            </Masonry>
-            <div className={styles.moreQuiz} onClick={handleMoreQuiz}>
-              <p>
-                {isLoadingMore
-                  ? "추가 퀴즈를 생성하고 있어요..."
-                  : "+ 다른 퀴즈도 보고싶어요"}
-              </p>
+  const handleSubmit = () => {
+    if (onSubmit && selectedQuizzes.length > 0) {
+      onSubmit(selectedQuizzes);
+    }
+    setShowPreviewModal(false);
+  };
+
+  return (
+    <>
+      <div className={styles.wrapper}>
+        {error && (
+          <AlertModal
+            onClose={() => {
+              setError(null);
+              if (onClose) onClose();
+            }}
+          >
+            {error}
+          </AlertModal>
+        )}
+        {showAlert && (
+          <AlertModal onClose={() => setShowAlert(false)}>
+            최대 4개의 퀴즈만 선택할 수 있습니다.
+          </AlertModal>
+        )}
+        <div className={styles.content}>
+          {isLoading ? (
+            <div className={styles.loading}>
+              <LoadingSpinner
+                text={["AI가 퀴즈를 만들고 있어요", "잠시만 기다려주세요!"]}
+              />
             </div>
+          ) : (
+            <div className={styles.quizContainer}>
+              <Masonry
+                breakpointCols={breakpointColumnsObj}
+                className={styles.masonryGrid}
+                columnClassName={styles.masonryColumn}
+              >
+                {quizzes?.map((quiz, index) => (
+                  <div
+                    key={index}
+                    className={`${styles.quizCard} ${
+                      selectedQuizzes.includes(quiz) ? styles.selected : ""
+                    }`}
+                    onClick={() => handleQuizSelection(index)}
+                  >
+                    <div className={styles.quizCardHeader}>
+                      <div className={styles.quizCardHeaderContent}>
+                        <div className={styles.type}>
+                          {quiz.type === "multipleChoice"
+                            ? "객관식"
+                            : quiz.type === "shortAnswer"
+                            ? "단답형"
+                            : "O/X"}
+                        </div>
+                        <div className={styles.question}>{quiz.quizBody}</div>
+                      </div>
+
+                      <div className={styles.selectButtonWrapper}>
+                        <SelectableButton
+                          selected={selectedQuizzes.includes(quiz)}
+                          onClick={(
+                            e?: React.MouseEvent<Element, MouseEvent>
+                          ) => {
+                            e?.stopPropagation();
+                            handleQuizSelection(index);
+                          }}
+                          disabled={false}
+                        />
+                      </div>
+                    </div>
+                    {quiz.type === "multipleChoice" &&
+                      quiz.options &&
+                      quiz.options.length > 0 && (
+                        <ul className={styles.choices}>
+                          {quiz.options.map((option, index) => (
+                            <li key={index}>
+                              {index + 1}. {option}
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    <div className={styles.answer}>정답: {quiz.solution}</div>
+                  </div>
+                ))}
+              </Masonry>
+              <div className={styles.moreQuiz} onClick={handleMoreQuiz}>
+                <p>
+                  {isLoadingMore
+                    ? "추가 퀴즈를 생성하고 있어요..."
+                    : "+ 다른 퀴즈도 보고싶어요"}
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+        {quizzes !== null && (
+          <div className={styles.buttonSection}>
+            <button
+              className={styles.customizing}
+              onClick={() => onCustomize && onCustomize(selectedQuizzes)}
+              disabled={selectedQuizzes.length === 0}
+            >
+              선택한 퀴즈를 기반으로 커스터마이징 하기
+            </button>
+            <button
+              className={styles.submit}
+              onClick={handlePreview}
+              disabled={selectedQuizzes.length === 0}
+            >
+              제출 전 미리보기
+            </button>
           </div>
         )}
       </div>
-      {quizzes !== null && (
-        <div className={styles.buttonSection}>
-          <button
-            className={styles.customizing}
-            onClick={() => onCustomize && onCustomize(selectedQuizzes)}
-            disabled={selectedQuizzes.length === 0}
-          >
-            선택한 퀴즈를 기반으로 커스터마이징 하기
-          </button>
-          <button
-            className={styles.submit}
-            onClick={() => {
-              if (onSubmit && selectedQuizzes.length > 0) {
-                onSubmit(selectedQuizzes);
-              }
-            }}
-            disabled={selectedQuizzes.length === 0}
-          >
-            제출 전 미리보기
-          </button>
-        </div>
+
+      {/* 제출 전 미리보기 모달 */}
+      {showPreviewModal && (
+        <QuizPreviewModal
+          quizzes={selectedQuizzes}
+          onClose={() => setShowPreviewModal(false)}
+          onSubmit={handleSubmit}
+          title="퀴즈 최종 확인"
+          description="아래 퀴즈들이 최종 제출됩니다. 확인 후 제출해주세요."
+          cancelButtonText="다시 선택하기"
+          submitButtonText="이대로 제출하기"
+        />
       )}
-    </div>
+    </>
   );
 };
 

--- a/frontend/components/Modal/MakeQuizModal/QuizPreview/QuizPreview.tsx
+++ b/frontend/components/Modal/MakeQuizModal/QuizPreview/QuizPreview.tsx
@@ -151,14 +151,17 @@ const QuizPreview = ({
                   onClick={() => handleQuizSelection(index)}
                 >
                   <div className={styles.quizCardHeader}>
-                    <div className={styles.type}>
-                      {quiz.type === "multipleChoice"
-                        ? "객관식"
-                        : quiz.type === "shortAnswer"
-                        ? "단답형"
-                        : "O/X"}
+                    <div className={styles.quizCardHeaderContent}>
+                      <div className={styles.type}>
+                        {quiz.type === "multipleChoice"
+                          ? "객관식"
+                          : quiz.type === "shortAnswer"
+                          ? "단답형"
+                          : "O/X"}
+                      </div>
+                      <div className={styles.question}>{quiz.quizBody}</div>
                     </div>
-                    <div className={styles.question}>{quiz.quizBody}</div>
+
                     <div className={styles.selectButtonWrapper}>
                       <SelectableButton
                         selected={selectedQuizzes.includes(quiz)}

--- a/frontend/components/Modal/MakeQuizModal/QuizPreviewModal/QuizPreviewModal.module.scss
+++ b/frontend/components/Modal/MakeQuizModal/QuizPreviewModal/QuizPreviewModal.module.scss
@@ -34,63 +34,65 @@
   padding-right: $spacing-sm;
 }
 
-.previewQuizBox {
-  background: $color-skyblue;
+// QuizToggleCard와 같은 카드 디자인
+.card {
+  background-color: $color-white;
   border-radius: $radius-md;
-  padding: $spacing-md;
-  border: 1px solid $color-neutral-6;
+  padding: $spacing-lg;
+  transition: $transition-fast;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  border: 1px solid $color-neutral-7;
 }
 
-.previewQuizHeader {
+.header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: $spacing-md;
+  color: $color-neutral-1;
+
+  .headerLeft {
+    display: flex;
+    align-items: center;
+    gap: $spacing-sm;
+  }
+
+  .index {
+    font-size: $font-size-md;
+    font-weight: $font-weight-medium;
+  }
+
+  .checkIcon {
+    font-size: 18px;
+    color: $color-blue;
+  }
 }
 
-.previewTypeLabel {
-  color: $color-blue;
-  background: $color-white;
-  border-radius: $radius-full;
-  padding: $spacing-xs $spacing-sm;
-  font-weight: bold;
-  display: inline-block;
-  font-size: $font-size-md;
-  width: fit-content;
-  white-space: nowrap;
-  border: 1px solid $color-blue;
-}
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-md;
 
-.previewQuestion {
-  font-size: $font-size-md;
-  font-weight: $font-weight-medium;
-  color: $color-neutral-2;
-  margin-bottom: $spacing-md;
-  line-height: 1.5;
-}
+  .quizTitle {
+    margin-top: $spacing-md;
+    padding-top: $spacing-md;
+    border-top: 1px solid $color-neutral-7;
+    font-size: $font-size-md;
+    font-weight: $font-weight-regular;
+    word-wrap: break-word;
+    color: $color-neutral-1;
+  }
 
-.previewOptions {
-  margin-bottom: $spacing-md;
-}
+  .quizContent {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-md;
+  }
 
-.previewOption {
-  padding: $spacing-xs $spacing-sm;
-  margin-bottom: $spacing-xs;
-  background: $color-white;
-  border-radius: $radius-sm;
-  border: 1px solid $color-neutral-6;
-  font-size: $font-size-sm;
-  color: $color-neutral-3;
-}
-
-.previewAnswer {
-  font-size: $font-size-md;
-  font-weight: $font-weight-bold;
-  color: $color-blue;
-  padding: $spacing-sm;
-  background: $color-white;
-  border-radius: $radius-sm;
-  border: 1px solid $color-blue;
+  .choiceButtons {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-xs;
+  }
 }
 
 .previewButtonSection {

--- a/frontend/components/Modal/MakeQuizModal/QuizPreviewModal/QuizPreviewModal.module.scss
+++ b/frontend/components/Modal/MakeQuizModal/QuizPreviewModal/QuizPreviewModal.module.scss
@@ -1,0 +1,158 @@
+// 미리보기 모달 스타일
+.previewWrapper {
+  display: flex;
+  flex-direction: column;
+  width: 800px;
+  max-height: 80vh;
+  transition: $transition-fast;
+  @include respond-to(md) {
+    max-width: 100%;
+  }
+  gap: $spacing-sm;
+  overflow: hidden;
+}
+
+.previewTitle {
+  font-size: $font-size-xl;
+  font-weight: bold;
+  color: $color-blue;
+}
+
+.previewDescription {
+  font-size: $font-size-md;
+  color: $color-neutral-5;
+  padding-bottom: $spacing-md;
+  border-bottom: 1px solid $color-neutral-6;
+}
+
+.previewQuizList {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-md;
+  overflow: auto;
+  max-height: 60vh;
+  padding-right: $spacing-sm;
+}
+
+.previewQuizBox {
+  background: $color-skyblue;
+  border-radius: $radius-md;
+  padding: $spacing-md;
+  border: 1px solid $color-neutral-6;
+}
+
+.previewQuizHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: $spacing-md;
+}
+
+.previewTypeLabel {
+  color: $color-blue;
+  background: $color-white;
+  border-radius: $radius-full;
+  padding: $spacing-xs $spacing-sm;
+  font-weight: bold;
+  display: inline-block;
+  font-size: $font-size-md;
+  width: fit-content;
+  white-space: nowrap;
+  border: 1px solid $color-blue;
+}
+
+.previewQuestion {
+  font-size: $font-size-md;
+  font-weight: $font-weight-medium;
+  color: $color-neutral-2;
+  margin-bottom: $spacing-md;
+  line-height: 1.5;
+}
+
+.previewOptions {
+  margin-bottom: $spacing-md;
+}
+
+.previewOption {
+  padding: $spacing-xs $spacing-sm;
+  margin-bottom: $spacing-xs;
+  background: $color-white;
+  border-radius: $radius-sm;
+  border: 1px solid $color-neutral-6;
+  font-size: $font-size-sm;
+  color: $color-neutral-3;
+}
+
+.previewAnswer {
+  font-size: $font-size-md;
+  font-weight: $font-weight-bold;
+  color: $color-blue;
+  padding: $spacing-sm;
+  background: $color-white;
+  border-radius: $radius-sm;
+  border: 1px solid $color-blue;
+}
+
+.previewButtonSection {
+  margin-top: auto;
+  border-top: 1px solid $color-neutral-6;
+  padding: $spacing-sm 0;
+  display: flex;
+  justify-content: center;
+  gap: $spacing-md;
+  background: white;
+
+  button {
+    padding: $spacing-sm $spacing-lg;
+    font-weight: $font-weight-medium;
+    @include common-input-button-style;
+    border-radius: $radius-lg;
+    border: none;
+    cursor: pointer;
+    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+
+    &:disabled {
+      background-color: $color-neutral-7;
+      color: $color-neutral-5;
+      border-color: $color-neutral-6;
+      cursor: not-allowed;
+      transform: none;
+
+      &:hover {
+        transform: none;
+      }
+    }
+
+    &:not(:disabled) {
+      &:hover {
+        transform: scale(1.02);
+      }
+
+      &:active {
+        transform: scale(0.98);
+      }
+    }
+
+    &.previewSubmitButton {
+      background-color: $color-blue;
+      color: white;
+
+      &:disabled {
+        background-color: $color-neutral-7;
+        color: $color-neutral-5;
+      }
+    }
+
+    &.previewCancelButton {
+      background-color: $color-skyblue;
+      color: $color-blue;
+      border: 1px solid $color-blue;
+
+      &:disabled {
+        background-color: $color-neutral-8;
+        color: $color-neutral-5;
+        border-color: $color-neutral-6;
+      }
+    }
+  }
+}

--- a/frontend/components/Modal/MakeQuizModal/QuizPreviewModal/QuizPreviewModal.tsx
+++ b/frontend/components/Modal/MakeQuizModal/QuizPreviewModal/QuizPreviewModal.tsx
@@ -3,6 +3,9 @@
 import { Quiz } from "@/types/quizzes/createQuizTypes";
 import ClosableModal from "@/components/Modal/ClosableModal/ClosableModal";
 import styles from "./QuizPreviewModal.module.scss";
+import { CircleCheck } from "lucide-react";
+import QuizInput from "@/components/Input/QuizInput/QuizInput";
+import QuizChoiceButton from "@/components/Button/QuizChoiceButton/QuizChoiceButton";
 
 interface QuizPreviewModalProps {
   quizzes: Quiz[];
@@ -39,28 +42,48 @@ const QuizPreviewModal = ({
       }
     }
 
+    // OX 문제는 labels를 ["O", "X"]로 자동 설정
+    const getLabels = () => {
+      if (quiz.type === "trueFalse" && !quiz.options) {
+        return ["O", "X"];
+      }
+      return quiz.options;
+    };
+
     return (
-      <div key={idx} className={styles.previewQuizBox}>
-        <div className={styles.previewQuizHeader}>
-          <div className={styles.previewTypeLabel}>
-            {quiz.type === "multipleChoice"
-              ? "객관식"
-              : quiz.type === "shortAnswer"
-              ? "단답형"
-              : "O/X"}
+      <div key={idx} className={styles.card}>
+        <div className={styles.header}>
+          <div className={styles.headerLeft}>
+            <CircleCheck
+              className={styles.checkIcon}
+              size={24}
+              color="#4894FE"
+            />
+            <h1 className={styles.index}>퀴즈 {idx + 1}</h1>
           </div>
         </div>
-        <div className={styles.previewQuestion}>{quiz.quizBody}</div>
-        {quiz.type === "multipleChoice" && quiz.options && (
-          <div className={styles.previewOptions}>
-            {quiz.options.map((option, oIdx) => (
-              <div key={oIdx} className={styles.previewOption}>
-                {oIdx + 1}. {option}
+        <div className={styles.content}>
+          <h2 className={styles.quizTitle}>{quiz.quizBody}</h2>
+          <div className={styles.quizContent}>
+            {quiz.type === "multipleChoice" || quiz.type === "trueFalse" ? (
+              <div className={styles.choiceButtons}>
+                {getLabels()?.map((label) => (
+                  <QuizChoiceButton
+                    key={label}
+                    label={label}
+                    correctAnswer={displaySolution}
+                    mode="teacher"
+                  />
+                ))}
               </div>
-            ))}
+            ) : (
+              <QuizInput
+                mode="teacher"
+                correctAnswer={displaySolution}
+              />
+            )}
           </div>
-        )}
-        <div className={styles.previewAnswer}>정답: {displaySolution}</div>
+        </div>
       </div>
     );
   };

--- a/frontend/components/Modal/MakeQuizModal/QuizPreviewModal/QuizPreviewModal.tsx
+++ b/frontend/components/Modal/MakeQuizModal/QuizPreviewModal/QuizPreviewModal.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { Quiz } from "@/types/quizzes/createQuizTypes";
+import ClosableModal from "@/components/Modal/ClosableModal/ClosableModal";
+import styles from "./QuizPreviewModal.module.scss";
+
+interface QuizPreviewModalProps {
+  quizzes: Quiz[];
+  onClose: () => void;
+  onSubmit: () => void;
+  isSubmitting?: boolean;
+  title?: string;
+  description?: string;
+  cancelButtonText?: string;
+  submitButtonText?: string;
+}
+
+const QuizPreviewModal = ({
+  quizzes,
+  onClose,
+  onSubmit,
+  isSubmitting = false,
+  title = "퀴즈 최종 확인",
+  description = "아래 퀴즈들이 최종 제출됩니다. 확인 후 제출해주세요.",
+  cancelButtonText = "다시 수정하기",
+  submitButtonText = "이대로 제출하기",
+}: QuizPreviewModalProps) => {
+  const renderPreviewQuiz = (quiz: Quiz, idx: number) => {
+    // 객관식 퀴즈의 정답을 선택지 번호에서 선택지 텍스트로 변환
+    let displaySolution = quiz.solution;
+    if (quiz.type === "multipleChoice" && quiz.options && quiz.solution) {
+      const solutionNumber = parseInt(quiz.solution);
+      if (
+        !isNaN(solutionNumber) &&
+        solutionNumber >= 1 &&
+        solutionNumber <= quiz.options.length
+      ) {
+        displaySolution = quiz.options[solutionNumber - 1];
+      }
+    }
+
+    return (
+      <div key={idx} className={styles.previewQuizBox}>
+        <div className={styles.previewQuizHeader}>
+          <div className={styles.previewTypeLabel}>
+            {quiz.type === "multipleChoice"
+              ? "객관식"
+              : quiz.type === "shortAnswer"
+              ? "단답형"
+              : "O/X"}
+          </div>
+        </div>
+        <div className={styles.previewQuestion}>{quiz.quizBody}</div>
+        {quiz.type === "multipleChoice" && quiz.options && (
+          <div className={styles.previewOptions}>
+            {quiz.options.map((option, oIdx) => (
+              <div key={oIdx} className={styles.previewOption}>
+                {oIdx + 1}. {option}
+              </div>
+            ))}
+          </div>
+        )}
+        <div className={styles.previewAnswer}>정답: {displaySolution}</div>
+      </div>
+    );
+  };
+
+  return (
+    <ClosableModal onClose={onClose}>
+      <div className={styles.previewWrapper}>
+        <h2 className={styles.previewTitle}>{title}</h2>
+        <p className={styles.previewDescription}>{description}</p>
+
+        <div className={styles.previewQuizList}>
+          {quizzes.map((quiz, idx) => renderPreviewQuiz(quiz, idx))}
+        </div>
+
+        <div className={styles.previewButtonSection}>
+          <button
+            onClick={onClose}
+            className={styles.previewCancelButton}
+            disabled={isSubmitting}
+          >
+            {cancelButtonText}
+          </button>
+          <button
+            onClick={onSubmit}
+            className={styles.previewSubmitButton}
+            disabled={isSubmitting}
+          >
+            {submitButtonText}
+          </button>
+        </div>
+      </div>
+    </ClosableModal>
+  );
+};
+
+export default QuizPreviewModal;

--- a/frontend/types/lectures/fetchAudioFileTypes.ts
+++ b/frontend/types/lectures/fetchAudioFileTypes.ts
@@ -1,4 +1,4 @@
 export interface FetchAudioFileResult {
   lectureId: string;
-  audioUrl: string;
+  audioName: string;
 }

--- a/frontend/types/lectures/fetchAudioFileTypes.ts
+++ b/frontend/types/lectures/fetchAudioFileTypes.ts
@@ -1,4 +1,6 @@
 export interface FetchAudioFileResult {
   lectureId: string;
   audioName: string;
+  audioUrl: string;
+  fileSize: string;
 }


### PR DESCRIPTION
### 👀 관련 이슈

#219

#220

### ✨ 작업한 내용

- [강의 녹음본 컴포넌트에서 audioUrl을 audioName으로 변경 및 타입 수정](https://github.com/KW-ClassLog/ClassLog/commit/58941654d2d3ca767f0f8504516fa105ab1c52fc)
- [강의 녹음본 컴포넌트에 다운로드 기능 추가 및 스타일 수정](https://github.com/KW-ClassLog/ClassLog/commit/b77a4bb227c2d049c9cf928fc509e1381f2c4fec)
- [강의 녹음본 컴포넌트의 오디오 플레이어 높이를 40px에서 50px로 수정](https://github.com/KW-ClassLog/ClassLog/commit/36fb85a009e6df2f20aa429f96c43e256855e9fc)
- [질문 목록 컴포넌트에서 초기 질문 데이터를 빈 배열로 변경](https://github.com/KW-ClassLog/ClassLog/commit/53a848bb2601b596e0ce6f0491bfd771b5cd63e0)
- [파일 선택 모달에 로딩 스피너 추가 및 로딩 텍스트 수정](https://github.com/KW-ClassLog/ClassLog/commit/38a352f8b4535ae1ae802d5948e8d9fbd51e2f30)
- [퀴즈 미리보기 컴포넌트의 스타일 수정 및 헤더 구조 변경](https://github.com/KW-ClassLog/ClassLog/pull/222/commits/2bd222ec574139acf62a0240722a5262429931c7)
- [퀴즈 커스터마이징 모달에 사용자 생성 퀴즈 추가 기능 및 스타일 개선](https://github.com/KW-ClassLog/ClassLog/pull/222/commits/0b6af27e4ed1499f7e6ce36ef454158493d0e2d6)
- [퀴즈 미리보기 모달에서 선택한 사람 수를 선택적 속성으로 변경하고, 스타일을 개선하여 카드 디자인 적용](https://github.com/KW-ClassLog/ClassLog/pull/222/commits/a8210d94d14e7f1959421d8cd044161f4b132ab6)

### 🌀 PR Point

- 강의자료 dd에서 녹음파일 잘 뜨는지, 잘 실행되는지, 다운로드 잘 되는지 확인
- 강의자료 선택하기 모달에서 로딩스피너 뜨는지 확인


### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|   녹음본 재생바, 다운로드버튼 + 질문목록 데모데이터 제거   |    <img width="1710" alt="image" src="https://github.com/user-attachments/assets/fa25b1a1-499f-4fea-ac7a-4da1500ac819" />      |
|   파일 선택 모달에 로딩 스피너 추가    |     <img width="1710" alt="image" src="https://github.com/user-attachments/assets/fce5690e-5615-46a1-a740-aff39ad5580d" />     |
|   직접 퀴즈 만들기 기능   |     <img width="801" alt="image" src="https://github.com/user-attachments/assets/0ff59c64-0be0-4d44-a264-8adf941c90d3" />    |
| 제출 전 미리보기     |     <img width="1324" alt="image" src="https://github.com/user-attachments/assets/2919d67a-44c0-419c-bb3e-c8cdaa66ea79" />    |

