### PR TITLE
✨ Feat/#230 강의 삭제 api 연동

### DIFF
--- a/frontend/api/lectures/deleteLecture.ts
+++ b/frontend/api/lectures/deleteLecture.ts
@@ -1,0 +1,19 @@
+import { axiosInstance } from "@/api/axiosInstance";
+import axios from "axios";
+import { ENDPOINTS } from "@/constants/endpoints";
+import { ApiResponse } from "@/types/apiResponseTypes";
+
+export async function deleteLecture(lectureId: string) {
+  try {
+    const response = await axiosInstance.delete<ApiResponse<void>>(
+      ENDPOINTS.LECTURES.DELETE(lectureId)
+    );
+
+    return response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error) && error.response) {
+      return error.response.data as ApiResponse<string | null>;
+    }
+    throw error;
+  }
+}

--- a/frontend/app/teacher/lecture-detail/[lectureId]/_components/BackButtonHeader/BackButtonHeader.module.scss
+++ b/frontend/app/teacher/lecture-detail/[lectureId]/_components/BackButtonHeader/BackButtonHeader.module.scss
@@ -3,6 +3,13 @@
   display: flex;
   align-items: center;
   height: 6vh;
+  justify-content: space-between;
+}
+
+.buttonContainer {
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .backBtn {

--- a/frontend/app/teacher/lecture-detail/[lectureId]/_components/BackButtonHeader/BackButtonHeader.tsx
+++ b/frontend/app/teacher/lecture-detail/[lectureId]/_components/BackButtonHeader/BackButtonHeader.tsx
@@ -6,23 +6,52 @@ import IconButton from "@/components/Button/IconButton/IconButton";
 import { useRouter } from "next/navigation";
 import { ROUTES } from "@/constants/routes";
 import ConfirmModal from "@/components/Modal/ConfirmModal/ConfirmModal";
+import AlertModal from "@/components/Modal/AlertModal/AlertModal";
+import { deleteLecture } from "@/api/lectures/deleteLecture";
 
-export default function BackButtonHeader() {
+export default function BackButtonHeader({ lectureId }: { lectureId: string }) {
   const router = useRouter();
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showAlertModal, setShowAlertModal] = useState(false);
+  const [alertMessage, setAlertMessage] = useState("");
+  const [isSuccess, setIsSuccess] = useState(false);
 
   const handleDeleteClick = () => {
     setShowDeleteModal(true);
   };
 
-  const handleDeleteConfirm = () => {
-    // TODO: 실제 삭제 로직 구현
-    console.log("강의 삭제 실행");
-    setShowDeleteModal(false);
+  const handleDeleteConfirm = async () => {
+    try {
+      const response = await deleteLecture(lectureId);
+
+      if (response.isSuccess) {
+        setAlertMessage("강의가 성공적으로 삭제되었습니다.");
+        setIsSuccess(true);
+      } else {
+        setAlertMessage(response.message || "강의 삭제에 실패했습니다.");
+        setIsSuccess(false);
+      }
+
+      setShowDeleteModal(false);
+      setShowAlertModal(true);
+    } catch (error) {
+      console.error(error);
+      setAlertMessage("강의 삭제 중 오류가 발생했습니다.");
+      setIsSuccess(false);
+      setShowDeleteModal(false);
+      setShowAlertModal(true);
+    }
   };
 
   const handleDeleteCancel = () => {
     setShowDeleteModal(false);
+  };
+
+  const handleAlertClose = () => {
+    setShowAlertModal(false);
+    if (isSuccess) {
+      router.push(ROUTES.teacherLectureManagement);
+    }
   };
 
   return (
@@ -54,6 +83,10 @@ export default function BackButtonHeader() {
         >
           정말 이 강의를 삭제하시겠습니까?
         </ConfirmModal>
+      )}
+
+      {showAlertModal && (
+        <AlertModal onClose={handleAlertClose}>{alertMessage}</AlertModal>
       )}
     </>
   );

--- a/frontend/app/teacher/lecture-detail/[lectureId]/_components/BackButtonHeader/BackButtonHeader.tsx
+++ b/frontend/app/teacher/lecture-detail/[lectureId]/_components/BackButtonHeader/BackButtonHeader.tsx
@@ -1,21 +1,60 @@
 "use client";
-import React from "react";
-import { ArrowLeft } from "lucide-react";
+import React, { useState } from "react";
+import { ArrowLeft, Trash2, PencilLine } from "lucide-react";
 import styles from "./BackButtonHeader.module.scss";
 import IconButton from "@/components/Button/IconButton/IconButton";
 import { useRouter } from "next/navigation";
 import { ROUTES } from "@/constants/routes";
+import ConfirmModal from "@/components/Modal/ConfirmModal/ConfirmModal";
 
 export default function BackButtonHeader() {
   const router = useRouter();
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  const handleDeleteClick = () => {
+    setShowDeleteModal(true);
+  };
+
+  const handleDeleteConfirm = () => {
+    // TODO: 실제 삭제 로직 구현
+    console.log("강의 삭제 실행");
+    setShowDeleteModal(false);
+  };
+
+  const handleDeleteCancel = () => {
+    setShowDeleteModal(false);
+  };
 
   return (
-    <header className={styles.quizHeader}>
-      <IconButton
-        icon={<ArrowLeft />}
-        onClick={() => router.push(ROUTES.teacherLectureManagement)}
-        ariaLabel={""}
-      ></IconButton>
-    </header>
+    <>
+      <header className={styles.quizHeader}>
+        <IconButton
+          icon={<ArrowLeft />}
+          onClick={() => router.push(ROUTES.teacherLectureManagement)}
+          ariaLabel={"뒤로가기"}
+        ></IconButton>
+        <div className={styles.buttonContainer}>
+          <IconButton
+            icon={<PencilLine />}
+            onClick={() => {}}
+            ariaLabel={"수정"}
+          ></IconButton>
+          <IconButton
+            icon={<Trash2 />}
+            onClick={handleDeleteClick}
+            ariaLabel={"삭제"}
+          ></IconButton>
+        </div>
+      </header>
+
+      {showDeleteModal && (
+        <ConfirmModal
+          onConfirm={handleDeleteConfirm}
+          onClose={handleDeleteCancel}
+        >
+          정말 이 강의를 삭제하시겠습니까?
+        </ConfirmModal>
+      )}
+    </>
   );
 }

--- a/frontend/app/teacher/lecture-detail/[lectureId]/_components/LectureDetailContainer/LectureDetailContainer.tsx
+++ b/frontend/app/teacher/lecture-detail/[lectureId]/_components/LectureDetailContainer/LectureDetailContainer.tsx
@@ -1,17 +1,14 @@
 "use client";
-import { useParams } from "next/navigation";
 import LectureHeader from "../LectureHeader/LectureHeader";
 import LectureMainGrid from "../LectureMainGrid/LectureMainGrid";
 import { LectureDetailProvider } from "../LectureDetailContext";
 import style from "./LectureDetailContainer.module.scss";
 
-export default function LectureDetailContainer() {
-  const params = useParams();
-  // lectureId가 URL의 마지막 파라미터
-  const lectureId = Array.isArray(params.lectureId)
-    ? params.lectureId[params.lectureId.length - 1]
-    : params.lectureId;
-
+export default function LectureDetailContainer({
+  lectureId,
+}: {
+  lectureId: string;
+}) {
   return (
     <div className={style.lectureDetailContainer}>
       {lectureId && (

--- a/frontend/app/teacher/lecture-detail/[lectureId]/page.tsx
+++ b/frontend/app/teacher/lecture-detail/[lectureId]/page.tsx
@@ -1,12 +1,20 @@
+"use client";
+import { useParams } from "next/navigation";
 import BackButtonHeader from "./_components/BackButtonHeader/BackButtonHeader";
 import LectureDetailContainer from "./_components/LectureDetailContainer/LectureDetailContainer";
 import style from "./page.module.scss";
 
 export default function TeacherLectureDetailPage() {
+  const params = useParams();
+  // lectureId가 URL의 마지막 파라미터
+  const lectureId = Array.isArray(params.lectureId)
+    ? params.lectureId[params.lectureId.length - 1]
+    : params.lectureId;
+
   return (
     <div className={style.lectureDetailPage}>
-      <BackButtonHeader />
-      <LectureDetailContainer />
+      <BackButtonHeader lectureId={lectureId as string} />
+      <LectureDetailContainer lectureId={lectureId as string} />
     </div>
   );
 }


### PR DESCRIPTION
### 👀 관련 이슈

#230 

### ✨ 작업한 내용

- [강의 상세 페이지의 뒤로가기 버튼 헤더에 수정 및 삭제 버튼 추가, 삭제 확인 모달 구현](https://github.com/KW-ClassLog/ClassLog/commit/25f4bc4f59a7635860a6d5d328ee18821b81521a)
- [강의 삭제 기능 추가 및 강의 상세 페이지에서 lectureId 전달 구현](https://github.com/KW-ClassLog/ClassLog/commit/638797b081873db8c012d73c06206e54025f3c49)

### 🌀 PR Point

- 강의 상세 들어가서 강의 삭제해보기

### 🍰 참고사항

* 강의 수정 기능은 아직입니다!!!


### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|   강의 삭제   |    ![강의삭제](https://github.com/user-attachments/assets/b2529951-0dcb-455b-8532-2523cae141d2)      |
