### PR TITLE
🐛 Fix/#224 퀴즈 불가능한 파일과 가능한 파일 함께 있을시 퀴즈 생성 가능하도록 수정

### DIFF
--- a/backend/src/main/java/org/example/backend/domain/quiz/service/QuizServiceImpl.java
+++ b/backend/src/main/java/org/example/backend/domain/quiz/service/QuizServiceImpl.java
@@ -79,12 +79,14 @@ public class QuizServiceImpl implements QuizService {
             audioUrl = s3Service.getPresignedUrl(lecture.getAudioUrl());
         }
 
-        List<String> allowedExtensions = Arrays.asList(".pdf", ".pptx", ".docx", ".hwp");
+        List<String> allowedExtensions = Arrays.asList(".pdf", ".pptx", ".docx", ".hwp", ".hwpx");
 
         List<LectureNote> filteredNotes = notes.stream()
                 .filter(note -> {
-                    String url = note.getNoteUrl().toLowerCase();
-                    return allowedExtensions.stream().anyMatch(url::endsWith);
+                    String url = note.getNoteUrl();
+                    if (url == null) return false;
+                    String lowerUrl = url.toLowerCase();
+                    return allowedExtensions.stream().anyMatch(lowerUrl::endsWith);
                 })
                 .toList();
 


### PR DESCRIPTION
### 👀 관련 이슈

#224 
<!-- 관련 이슈를 적어주세요 -->

### ✨ 작업한 내용

[퀴즈 불가능한 파일과 가능한 파일 함께 있을시 퀴즈 생성 가능하도록 수정](https://github.com/KW-ClassLog/ClassLog/commit/341ca60e3c0ba000aab0963a29224c93f8217881)
<!-- 작업한 내용을 적어주세요 -->

### 🌀 PR Point

pdf, pptx, docx, hwp, hwpx 파일과 이 외에 파일이 있을 경우에 퀴즈 생성 잘 되는지 확인해주세요.
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

Docker 컨테이너 지우고 ./gradlew clean build 후에 다시 build 해야합니다.
<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|      |          |
