### PR TITLE
✨ Feat/#241 학생 목록 불러오기 api 연동

### DIFF
--- a/frontend/api/student-classes/fetchStudentsByClass.ts
+++ b/frontend/api/student-classes/fetchStudentsByClass.ts
@@ -1,0 +1,19 @@
+import { axiosInstance } from "@/api/axiosInstance";
+import axios from "axios";
+import { ENDPOINTS } from "@/constants/endpoints";
+import { ApiResponse } from "@/types/apiResponseTypes";
+import { FetchStudentsByClassResult } from "@/types/student-classes/fetchStudentsByClassTypes";
+
+export async function fetchStudentsByClass(classId: string) {
+  try {
+    const response = await axiosInstance.get<
+      ApiResponse<FetchStudentsByClassResult[]>
+    >(ENDPOINTS.STUDENT_CLASSES.GET_STUDENTS(classId));
+    return response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error) && error.response) {
+      return error.response.data as ApiResponse<FetchStudentsByClassResult[]>;
+    }
+    throw error;
+  }
+}

--- a/frontend/app/teacher/lecture-management/page.tsx
+++ b/frontend/app/teacher/lecture-management/page.tsx
@@ -37,7 +37,7 @@ export default function TeacherLectureManagementPage() {
   if (!selectedClassId || !selectedClassName) {
     return (
       <div className={styles.container}>
-        <h1>퀴즈 관리</h1>
+        <h1>강의 관리</h1>
         <NoDataView
           icon={BookOpenText}
           title="선택된 클래스가 없습니다"

--- a/frontend/app/teacher/lecturenote-management/page.tsx
+++ b/frontend/app/teacher/lecturenote-management/page.tsx
@@ -106,7 +106,7 @@ export default function TeacherLectureNoteManagementPage() {
   if (!selectedClassId || !selectedClassName) {
     return (
       <div className={styles.container}>
-        <h1>퀴즈 관리</h1>
+        <h1>강의자료 관리</h1>
         <NoDataView
           icon={FileText}
           title="선택된 클래스가 없습니다"

--- a/frontend/app/teacher/quiz-management/page.module.scss
+++ b/frontend/app/teacher/quiz-management/page.module.scss
@@ -1,13 +1,12 @@
 .container {
   padding: $spacing-xl;
-  height: calc(100vh - 6vh);
+  height: calc(100vh - 80px);
   display: flex;
   flex-direction: column;
 
   h1 {
     font-size: $font-size-xl;
     font-weight: $font-weight-bold;
-    margin-bottom: $spacing-lg;
   }
 
   // NoDataView가 있을 때는 중앙 정렬

--- a/frontend/app/teacher/student-management/page.tsx
+++ b/frontend/app/teacher/student-management/page.tsx
@@ -4,87 +4,34 @@ import ManagementTable from "@/components/ManagementTable/ManagementTable";
 import useSelectedClassStore from "@/store/useSelectedClassStore";
 import styles from "./page.module.scss";
 import MakeInvitationCodeModal from "@/components/Modal/MakeInvitationCodeModal/MakeInvitationCodeModal";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import NoDataView from "@/components/NoDataView/NoDataView";
 import { UsersRound } from "lucide-react";
+import LoadingSpinner from "@/components/LoadingSpinner/LoadingSpinner";
+import { FetchStudentsByClassResult } from "@/types/student-classes/fetchStudentsByClassTypes";
+import { fetchStudentsByClass } from "@/api/student-classes/fetchStudentsByClass";
 
 export default function TeacherStudentManagementPage() {
   const { selectedClassId, selectedClassName } = useSelectedClassStore();
   const [isInviteModalOpen, setIsInviteModalOpen] = React.useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [students, setStudents] = useState<FetchStudentsByClassResult[]>([]);
 
-  const students = [
-    {
-      userId: "user1",
-      name: "김클로",
-      nickname: "김클로",
-      phoneNumber: "010-0000-0000",
-      organization: "광운대학교",
-    },
-    {
-      userId: "user2",
-      name: "주세원",
-      nickname: "강백호",
-      phoneNumber: "010-0000-0000",
-      organization: "광운대학교",
-    },
-    {
-      userId: "user3",
-      name: "김해민",
-      nickname: "로하스",
-      phoneNumber: "010-0000-0000",
-      organization: "광운대학교",
-    },
-    {
-      userId: "user4",
-      name: "김수민",
-      nickname: "허경민",
-      phoneNumber: "010-0000-0000",
-      organization: "광운대학교",
-    },
-    {
-      userId: "user5",
-      name: "김수민",
-      nickname: "김민혁",
-      phoneNumber: "010-0000-0000",
-      organization: "광운대학교",
-    },
-    {
-      userId: "user6",
-      name: "김수민",
-      nickname: "장성우",
-      phoneNumber: "010-0000-0000",
-      organization: "광운대학교",
-    },
-    {
-      userId: "user7",
-      name: "김수민",
-      nickname: "천성호",
-      phoneNumber: "010-0000-0000",
-      organization: "광운대학교",
-    },
-    {
-      userId: "user8",
-      name: "김수민",
-      nickname: "배정대",
-      phoneNumber: "010-0000-0000",
-      organization: "광운대학교",
-    },
-    {
-      userId: "user9",
-      name: "김수민",
-      nickname: "김상수",
-      phoneNumber: "010-0000-0000",
-      organization: "광운대학교",
-    },
-    {
-      userId: "user10",
-      name: "김수민",
-      nickname: "윤준혁",
-      phoneNumber: "010-0000-0000",
-      organization: "광운대학교",
-    },
-    // 추가적인 학생 데이터
-  ];
+  // 학생 목록 불러오기
+  const loadStudents = async (classId: string) => {
+    setIsLoading(true);
+    const response = await fetchStudentsByClass(classId);
+    if (response.isSuccess && response.result) {
+      setStudents(response.result);
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (selectedClassId) {
+      loadStudents(selectedClassId);
+    }
+  }, [selectedClassId]);
 
   // 삭제 함수
   const handleDelete = () => {
@@ -94,6 +41,15 @@ export default function TeacherStudentManagementPage() {
     // );
     // 이제 삭제된 학생을 반영하는 로직을 추가할 수 있습니다.
   };
+
+  if (isLoading) {
+    return (
+      <div className={styles.container}>
+        <h1>[{selectedClassName}] 학생 관리</h1>
+        <LoadingSpinner />
+      </div>
+    );
+  }
 
   if (!selectedClassId || !selectedClassName) {
     return (

--- a/frontend/app/teacher/student-management/page.tsx
+++ b/frontend/app/teacher/student-management/page.tsx
@@ -5,6 +5,8 @@ import useSelectedClassStore from "@/store/useSelectedClassStore";
 import styles from "./page.module.scss";
 import MakeInvitationCodeModal from "@/components/Modal/MakeInvitationCodeModal/MakeInvitationCodeModal";
 import React from "react";
+import NoDataView from "@/components/NoDataView/NoDataView";
+import { UsersRound } from "lucide-react";
 
 export default function TeacherStudentManagementPage() {
   const { selectedClassId, selectedClassName } = useSelectedClassStore();
@@ -92,6 +94,19 @@ export default function TeacherStudentManagementPage() {
     // );
     // 이제 삭제된 학생을 반영하는 로직을 추가할 수 있습니다.
   };
+
+  if (!selectedClassId || !selectedClassName) {
+    return (
+      <div className={styles.container}>
+        <h1>학생 관리</h1>
+        <NoDataView
+          icon={UsersRound}
+          title="선택된 클래스가 없습니다"
+          description="좌상단의 클래스 선택 메뉴에서 클래스를 선택해주세요"
+        />
+      </div>
+    );
+  }
 
   return (
     <div className={styles.container}>

--- a/frontend/components/ManagementTable/ManagementTable.tsx
+++ b/frontend/components/ManagementTable/ManagementTable.tsx
@@ -9,12 +9,13 @@ import { FetchLectureNotesByClassResult } from "@/types/lectures/fetchLectureNot
 import NoDataView from "../NoDataView/NoDataView";
 import { FileText } from "lucide-react";
 import LectureNoteRow from "./_components/LectureNoteRow";
-import StudentRow, { StudentData } from "./_components/StudentRow";
+import StudentRow from "./_components/StudentRow";
 import { deleteLectureNote } from "@/api/lectures/deleteLectureNote";
+import { FetchStudentsByClassResult } from "@/types/student-classes/fetchStudentsByClassTypes";
 
 type ManagementTableProps = {
   type: "lectureNote" | "student"; // 데이터 유형
-  data: (FetchLectureNotesByClassResult | StudentData)[]; // lectureNote와 student에 맞는 데이터
+  data: FetchLectureNotesByClassResult[] | FetchStudentsByClassResult[]; // lectureNote와 student에 맞는 데이터
   onDelete: (index: string[]) => void; // 삭제 이벤트 처리 함수
 };
 
@@ -39,7 +40,7 @@ const ManagementTable: React.FC<ManagementTableProps> = ({
         data.map((item) =>
           type === "lectureNote"
             ? (item as FetchLectureNotesByClassResult).lectureNoteId
-            : (item as StudentData).userId
+            : (item as FetchStudentsByClassResult).userId
         )
       );
       setSelectedItems(allSelectedItems); // 전체 선택
@@ -163,13 +164,13 @@ const ManagementTable: React.FC<ManagementTableProps> = ({
                 key={
                   type === "lectureNote"
                     ? (item as FetchLectureNotesByClassResult).lectureNoteId
-                    : (item as StudentData).userId
+                    : (item as FetchStudentsByClassResult).userId
                 }
                 className={
                   selectedItems.has(
                     type === "lectureNote"
                       ? (item as FetchLectureNotesByClassResult).lectureNoteId
-                      : (item as StudentData).userId
+                      : (item as FetchStudentsByClassResult).userId
                   )
                     ? styles.selectedRow
                     : ""
@@ -183,7 +184,7 @@ const ManagementTable: React.FC<ManagementTableProps> = ({
                           type === "lectureNote"
                             ? (item as FetchLectureNotesByClassResult)
                                 .lectureNoteId
-                            : (item as StudentData).userId
+                            : (item as FetchStudentsByClassResult).userId
                         )
                           ? styles.selected
                           : ""
@@ -193,7 +194,7 @@ const ManagementTable: React.FC<ManagementTableProps> = ({
                           type === "lectureNote"
                             ? (item as FetchLectureNotesByClassResult)
                                 .lectureNoteId
-                            : (item as StudentData).userId
+                            : (item as FetchStudentsByClassResult).userId
                         )
                       }
                     >
@@ -207,7 +208,7 @@ const ManagementTable: React.FC<ManagementTableProps> = ({
                   />
                 ) : (
                   <StudentRow
-                    item={item as StudentData}
+                    item={item as FetchStudentsByClassResult}
                     isEditMode={isEditMode}
                     handleCopyPhoneNumber={handleCopyPhoneNumber}
                   />

--- a/frontend/components/ManagementTable/_components/StudentRow.tsx
+++ b/frontend/components/ManagementTable/_components/StudentRow.tsx
@@ -1,18 +1,10 @@
 import Image from "next/image";
 import styles from "../ManagementTable.module.scss";
 import { Copy } from "lucide-react";
-
-export type StudentData = {
-  userId: string;
-  name: string;
-  nickname: string;
-  phoneNumber: string;
-  organization?: string;
-  profile?: string;
-};
+import { FetchStudentsByClassResult } from "@/types/student-classes/fetchStudentsByClassTypes";
 
 interface Props {
-  item: StudentData;
+  item: FetchStudentsByClassResult;
   isEditMode: boolean;
   handleCopyPhoneNumber: (phone: string) => void;
 }
@@ -25,13 +17,14 @@ const StudentRow: React.FC<Props> = ({
   <>
     <td className={styles.profileContainer}>
       <Image
-        src={item.profile || "/images/default_profile.jpg"}
+        src={item.profileUrl || "/images/default_profile.jpg"}
         alt={item.name}
         width={40}
         height={40}
         className={styles.profileImage}
       />
-      {item.nickname}
+      {item.name}
+      {item.nickname && ` (${item.nickname})`}
     </td>
     <td>{item.organization}</td>
     <td>
@@ -40,7 +33,9 @@ const StudentRow: React.FC<Props> = ({
         <button
           className={styles.copyButton}
           onClick={() =>
-            handleCopyPhoneNumber((item as StudentData).phoneNumber)
+            handleCopyPhoneNumber(
+              (item as FetchStudentsByClassResult).phoneNumber
+            )
           }
         >
           <Copy className={styles.pasteIcon} />

--- a/frontend/constants/endpoints.ts
+++ b/frontend/constants/endpoints.ts
@@ -41,13 +41,17 @@ export const ENDPOINTS = {
 
     GET_LECTURES: (classId: string) =>
       `${BASE_API}/classes/${classId}/lectures`,
-    GET_STUDENTS: (classId: string) =>
-      `${BASE_API}/classes/${classId}/students`,
     GET_ENTRY_CODE: (classId: string) => `${BASE_API}/classes/${classId}/code`,
     ENTER: (classId: string) => `${BASE_API}/classes/${classId}/enter`,
     GET_ALL_NOTES: (classId: string) => `${BASE_API}/classes/${classId}/notes`,
     GET_MY_CLASSES: `${BASE_API}/classes/teacher/myclass`,
     GET_QUIZZES: (classId: string) => `${BASE_API}/classes/${classId}/quiz`,
+  },
+
+  // 학생 클래스 관련
+  STUDENT_CLASSES: {
+    GET_STUDENTS: (classId: string) =>
+      `${BASE_API}/student-classes/${classId}/students`,
   },
 
   // 강의 관련

--- a/frontend/types/student-classes/fetchStudentsByClassTypes.ts
+++ b/frontend/types/student-classes/fetchStudentsByClassTypes.ts
@@ -1,8 +1,8 @@
 export interface FetchStudentsByClassResult {
   userId: string;
   name: string;
-  nickname: string;
+  nickname: string | null;
   phoneNumber: string;
-  profileUrl: string;
+  profileUrl: string | null;
   organization: string;
 }

--- a/frontend/types/student-classes/fetchStudentsByClassTypes.ts
+++ b/frontend/types/student-classes/fetchStudentsByClassTypes.ts
@@ -1,0 +1,8 @@
+export interface FetchStudentsByClassResult {
+  userId: string;
+  name: string;
+  nickname: string;
+  phoneNumber: string;
+  profileUrl: string;
+  organization: string;
+}


### PR DESCRIPTION
### 👀 관련 이슈

#241

### ✨ 작업한 내용

- [강의 관리 및 강의자료 관리 페이지의 제목을 '퀴즈 관리'에서 각각 '강의 관리'와 '강의자료 관리'로 변경](https://github.com/KW-ClassLog/ClassLog/commit/a39fe89db68ef9bbe6e4978c2a85e8209681be69)
- [퀴즈 관리 페이지의 컨테이너 높이를 80px로 수정하여 레이아웃 개선](https://github.com/KW-ClassLog/ClassLog/commit/d402b741377868fc3806181e1a90c6a42d952efc)
- [학생 관리 페이지에 선택된 클래스가 없을 때 표시할 데이터 없음 뷰 추가](https://github.com/KW-ClassLog/ClassLog/commit/7960d94df5625977f98356c1a5904441c6a083da)
- [학생 클래스 API 추가 및 엔드포인트 수정](https://github.com/KW-ClassLog/ClassLog/commit/3f57dcd7857d0cecbeac61976ad10522b742fe3b)
- [학생 관리 페이지에서 선택된 클래스의 학생 목록을 API를 통해 불러오도록 수정하고, 로딩 상태를 표시하는 기능 추가](https://github.com/KW-ClassLog/ClassLog/commit/841cde4bd39c261c4b374b55c3dbdf88b2e8f77d)

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

우선 학생 명단이 없어서 빈화면으로 뜹니다
그래도 api 연동 테스트는 완료했습니다
학생 퇴장 기능은 백엔드 api 설계 나오면 추후에 추가하겠습니다

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|   학생관리 페이지   |    <img width="1710" alt="image" src="https://github.com/user-attachments/assets/70990e06-2da4-44a6-b795-cc263445d287" />      |
