### PR TITLE
✨ Feat/#304 실시간 채팅 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.600'
 	implementation 'com.amazonaws:aws-java-sdk-core:1.12.681'
 	implementation 'org.apache.commons:commons-lang3:3.12.0'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/org/example/backend/domain/question/controller/ChatController.java
+++ b/backend/src/main/java/org/example/backend/domain/question/controller/ChatController.java
@@ -1,0 +1,41 @@
+package org.example.backend.domain.question.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.backend.domain.question.dto.request.MessageRequestDTO;
+import org.example.backend.domain.question.service.ChatService;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.stereotype.Controller;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * STOMP 메시지 수신 & Redis Pub/Sub으로 전달
+ */
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final ChatService chatService;
+
+    /**
+     * 클라이언트기 "/pub/lecture/{lectureId}"로 메시지를 전송하면 해당 메시지를 redis pub/sub 채널로 publish
+     * @param lectureId
+     * @param messageDTO
+     */
+    @MessageMapping("/lecture/{lectureId}")
+    public void sendMessage(@DestinationVariable UUID lectureId, MessageRequestDTO.MessageDTO messageDTO) {
+        log.info("메시지 수신: {}", messageDTO);
+
+        messageDTO.setLectureId(lectureId);
+
+        if (messageDTO.getTimestamp() == null) {
+            messageDTO.setTimestamp(LocalDateTime.now());
+        }
+
+        chatService.sendMessage(messageDTO);
+    }
+}

--- a/backend/src/main/java/org/example/backend/domain/question/controller/ChatController.java
+++ b/backend/src/main/java/org/example/backend/domain/question/controller/ChatController.java
@@ -4,11 +4,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.backend.domain.question.dto.request.MessageRequestDTO;
 import org.example.backend.domain.question.service.ChatService;
+import org.example.backend.global.websocket.StompPrincipal;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Controller;
 
-import java.time.LocalDateTime;
+import java.security.Principal;
 import java.util.UUID;
 
 /**
@@ -27,11 +29,16 @@ public class ChatController {
      * @param messageDTO
      */
     @MessageMapping("/lecture/{lectureId}")
-    public void sendMessage(@DestinationVariable UUID lectureId, MessageRequestDTO.MessageDTO messageDTO) {
+    public void sendMessage(@DestinationVariable UUID lectureId,
+                            @Payload MessageRequestDTO.MessageDTO messageDTO,
+                            Principal principal) {
         log.info("메시지 수신: {}", messageDTO);
+        log.info("principal = {}", principal);
 
-        messageDTO.setLectureId(lectureId);
+        StompPrincipal stompPrincipal = (StompPrincipal) principal;
+        UUID userId = stompPrincipal.userId();
+        String role = stompPrincipal.role();
 
-        chatService.sendMessage(messageDTO);
+        chatService.sendMessage(lectureId,messageDTO,userId,role);
     }
 }

--- a/backend/src/main/java/org/example/backend/domain/question/controller/ChatController.java
+++ b/backend/src/main/java/org/example/backend/domain/question/controller/ChatController.java
@@ -32,10 +32,6 @@ public class ChatController {
 
         messageDTO.setLectureId(lectureId);
 
-        if (messageDTO.getTimestamp() == null) {
-            messageDTO.setTimestamp(LocalDateTime.now());
-        }
-
         chatService.sendMessage(messageDTO);
     }
 }

--- a/backend/src/main/java/org/example/backend/domain/question/dto/request/MessageRequestDTO.java
+++ b/backend/src/main/java/org/example/backend/domain/question/dto/request/MessageRequestDTO.java
@@ -1,6 +1,7 @@
 package org.example.backend.domain.question.dto.request;
 
 import lombok.*;
+import org.example.backend.domain.user.entity.Role;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -12,7 +13,8 @@ public class MessageRequestDTO {
         private UUID senderId;
         private String senderName;
         private String content;
-        private UUID lectureId;
+        private Role role;
+        private LocalDateTime timestamp;
     }
 }
 

--- a/backend/src/main/java/org/example/backend/domain/question/dto/request/MessageRequestDTO.java
+++ b/backend/src/main/java/org/example/backend/domain/question/dto/request/MessageRequestDTO.java
@@ -10,8 +10,9 @@ public class MessageRequestDTO {
     @Setter
     public static class MessageDTO {
         private UUID senderId;
-        private UUID lectureId;
+        private String senderName;
         private String content;
+        private UUID lectureId;
     }
 }
 

--- a/backend/src/main/java/org/example/backend/domain/question/dto/request/MessageRequestDTO.java
+++ b/backend/src/main/java/org/example/backend/domain/question/dto/request/MessageRequestDTO.java
@@ -12,6 +12,6 @@ public class MessageRequestDTO {
         private UUID senderId;
         private UUID lectureId;
         private String content;
-        private LocalDateTime timestamp;
     }
 }
+

--- a/backend/src/main/java/org/example/backend/domain/question/dto/request/MessageRequestDTO.java
+++ b/backend/src/main/java/org/example/backend/domain/question/dto/request/MessageRequestDTO.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 
 public class MessageRequestDTO {
     @Getter
-    @Setter
+    @Builder
     public static class MessageDTO {
         private UUID senderId;
         private String senderName;

--- a/backend/src/main/java/org/example/backend/domain/question/dto/request/MessageRequestDTO.java
+++ b/backend/src/main/java/org/example/backend/domain/question/dto/request/MessageRequestDTO.java
@@ -1,0 +1,17 @@
+package org.example.backend.domain.question.dto.request;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class MessageRequestDTO {
+    @Getter
+    @Setter
+    public static class MessageDTO {
+        private UUID senderId;
+        private UUID lectureId;
+        private String content;
+        private LocalDateTime timestamp;
+    }
+}

--- a/backend/src/main/java/org/example/backend/domain/question/exception/QuestionErrorCode.java
+++ b/backend/src/main/java/org/example/backend/domain/question/exception/QuestionErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum QuestionErrorCode implements BaseErrorCode {
-    _FORBIDDEN_LECTURE_ACCESS(HttpStatus.FORBIDDEN,"QUESTION403_1","해당 강의를 수강중인 학생만 조회가능합니다.");
+    _FORBIDDEN_LECTURE_ACCESS(HttpStatus.FORBIDDEN,"QUESTION403_1","해당 강의를 수강중인 학생만 조회가능합니다."),
+    _CHAT_MESSAGE_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "QUESTION500_1", "채팅 메시지 전송에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/backend/src/main/java/org/example/backend/domain/question/service/ChatService.java
+++ b/backend/src/main/java/org/example/backend/domain/question/service/ChatService.java
@@ -2,6 +2,8 @@ package org.example.backend.domain.question.service;
 
 import org.example.backend.domain.question.dto.request.MessageRequestDTO;
 
+import java.util.UUID;
+
 public interface ChatService {
-    void sendMessage(MessageRequestDTO.MessageDTO messageDTO);
+    void sendMessage(UUID lectureId, MessageRequestDTO.MessageDTO messageDTO, UUID userId, String role);
 }

--- a/backend/src/main/java/org/example/backend/domain/question/service/ChatService.java
+++ b/backend/src/main/java/org/example/backend/domain/question/service/ChatService.java
@@ -1,0 +1,7 @@
+package org.example.backend.domain.question.service;
+
+import org.example.backend.domain.question.dto.request.MessageRequestDTO;
+
+public interface ChatService {
+    void sendMessage(MessageRequestDTO.MessageDTO messageDTO);
+}

--- a/backend/src/main/java/org/example/backend/domain/question/service/ChatServiceImpl.java
+++ b/backend/src/main/java/org/example/backend/domain/question/service/ChatServiceImpl.java
@@ -13,6 +13,7 @@ import org.example.backend.domain.user.repository.UserRepository;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Slf4j
@@ -33,48 +34,44 @@ public class ChatServiceImpl implements ChatService {
 
         try{
             // 사용자 정보 조회
-            User user = userRepository.findById(userId)
+            User sender = userRepository.findById(userId)
                     .orElseThrow(() -> new UserException(UserErrorCode._USER_NOT_FOUND));
 
-            String senderName = user.getName();
+            String senderName = sender.getName();
 
             // 1. 메시지 저장
             // 저장용 DTO 구성
             MessageRequestDTO.MessageDTO originalMessage = MessageRequestDTO.MessageDTO.builder()
-                    .lectureId(lectureId)
                     .senderId(userId)
                     .senderName(senderName)
                     .content(messageDTO.getContent())
+                    .role(sender.getRole())
+                    .timestamp(LocalDateTime.now())
                     .build();
 
             String originalMessageJson = objectMapper.writeValueAsString(originalMessage); // DTO -> JSON 직렬화
 
             // Redis List 키 이름 지정(채팅 내용 저장용): chat:lecture:{lectureId}
             String redisListKey = "chat:lecture:"+ lectureId;
+
             // Redis list - 메시지 저장
             redisTemplate.opsForList().rightPush(redisListKey, originalMessageJson);
 
 
             // 2. 메시지 전파
-            // 2-1. teacher 메시지 전송
-            // Redis 채널 이름 지정: lecture:{lectureId}
-            String teacherChannel = "lecture:" + lectureId + ":TEACHER";
-            // Redis pub/sub - 메시지 전파
-            redisTemplate.convertAndSend(teacherChannel, originalMessageJson);
-
-            // 2-2. student 메시지 전송
             // 메시지 구성
             MessageRequestDTO.MessageDTO maskMessage = MessageRequestDTO.MessageDTO.builder()
-                    .lectureId(lectureId)
                     .senderId(null)
                     .senderName(null)
                     .content(messageDTO.getContent())
+                    .role(sender.getRole())
+                    .timestamp(LocalDateTime.now())
                     .build();
 
             String maskMessageJson = objectMapper.writeValueAsString(maskMessage); // DTO -> JSON 직렬화
 
             // Redis 채널 이름 지정: lecture:{lectureId}
-            String studentChannel = "lecture:" + lectureId + ":STUDENT";
+            String studentChannel = "lecture:" + lectureId;
             // Redis pub/sub - 메시지 전파
             redisTemplate.convertAndSend(studentChannel, maskMessageJson);
 

--- a/backend/src/main/java/org/example/backend/domain/question/service/ChatServiceImpl.java
+++ b/backend/src/main/java/org/example/backend/domain/question/service/ChatServiceImpl.java
@@ -1,0 +1,53 @@
+package org.example.backend.domain.question.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.backend.domain.question.dto.request.MessageRequestDTO;
+import org.example.backend.domain.question.exception.QuestionErrorCode;
+import org.example.backend.domain.question.exception.QuestionException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatServiceImpl implements ChatService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void sendMessage(MessageRequestDTO.MessageDTO messageDTO) {
+        /**
+         * STOMP로부터 수신한 메시지를 Redis Pub/Sub으로 전파하고,
+         * Redis List에 저장하는 메서드
+         */
+
+        try{
+            UUID lectureId = messageDTO.getLectureId();
+            String messageJson = objectMapper.writeValueAsString(messageDTO); // DTO -> JSON 직렬화
+
+            // Redis 채널 이름 지정: lecture:{lectureId}
+            String redisChannel = "lecture:"+ lectureId;
+            // Redis List 키 이름 지정(채팅 내용 저장용): chat:lecture:{lectureId}
+            String redisListKey = "chat:lecture:"+ lectureId;
+
+            // Redis pub/sub - 메시지 전파
+            redisTemplate.convertAndSend(redisChannel, messageJson);
+
+            // Redis list - 메시지 저장
+            redisTemplate.opsForList().rightPush(redisListKey, messageJson);
+
+            // 추후 제거
+            log.info("채팅 메시지 전송 성공 - lectureId={}, senderId={}, content={}",
+                    lectureId, messageDTO.getSenderId(), messageDTO.getContent());
+
+        } catch (Exception e){
+            log.error("채팅 메시지 전송 실패",e);
+            throw new QuestionException(QuestionErrorCode._CHAT_MESSAGE_SEND_FAIL);
+        }
+    }
+}

--- a/backend/src/main/java/org/example/backend/domain/question/service/ChatServiceImpl.java
+++ b/backend/src/main/java/org/example/backend/domain/question/service/ChatServiceImpl.java
@@ -6,6 +6,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.backend.domain.question.dto.request.MessageRequestDTO;
 import org.example.backend.domain.question.exception.QuestionErrorCode;
 import org.example.backend.domain.question.exception.QuestionException;
+import org.example.backend.domain.user.entity.User;
+import org.example.backend.domain.user.exception.UserErrorCode;
+import org.example.backend.domain.user.exception.UserException;
+import org.example.backend.domain.user.repository.UserRepository;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -18,32 +22,62 @@ public class ChatServiceImpl implements ChatService {
 
     private final RedisTemplate<String, String> redisTemplate;
     private final ObjectMapper objectMapper;
+    private final UserRepository userRepository;
 
     @Override
-    public void sendMessage(MessageRequestDTO.MessageDTO messageDTO) {
+    public void sendMessage(UUID lectureId, MessageRequestDTO.MessageDTO messageDTO, UUID userId, String role) {
         /**
          * STOMP로부터 수신한 메시지를 Redis Pub/Sub으로 전파하고,
          * Redis List에 저장하는 메서드
          */
 
         try{
-            UUID lectureId = messageDTO.getLectureId();
-            String messageJson = objectMapper.writeValueAsString(messageDTO); // DTO -> JSON 직렬화
+            // 사용자 정보 조회
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new UserException(UserErrorCode._USER_NOT_FOUND));
 
-            // Redis 채널 이름 지정: lecture:{lectureId}
-            String redisChannel = "lecture:"+ lectureId;
+            String senderName = user.getName();
+
+            // 1. 메시지 저장
+            // 저장용 DTO 구성
+            MessageRequestDTO.MessageDTO originalMessage = MessageRequestDTO.MessageDTO.builder()
+                    .lectureId(lectureId)
+                    .senderId(userId)
+                    .senderName(senderName)
+                    .content(messageDTO.getContent())
+                    .build();
+
+            String originalMessageJson = objectMapper.writeValueAsString(originalMessage); // DTO -> JSON 직렬화
+
             // Redis List 키 이름 지정(채팅 내용 저장용): chat:lecture:{lectureId}
             String redisListKey = "chat:lecture:"+ lectureId;
-
-            // Redis pub/sub - 메시지 전파
-            redisTemplate.convertAndSend(redisChannel, messageJson);
-
             // Redis list - 메시지 저장
-            redisTemplate.opsForList().rightPush(redisListKey, messageJson);
+            redisTemplate.opsForList().rightPush(redisListKey, originalMessageJson);
 
-            // 추후 제거
-            log.info("채팅 메시지 전송 성공 - lectureId={}, senderId={}, content={}",
-                    lectureId, messageDTO.getSenderId(), messageDTO.getContent());
+
+            // 2. 메시지 전파
+            // 2-1. teacher 메시지 전송
+            // Redis 채널 이름 지정: lecture:{lectureId}
+            String teacherChannel = "lecture:" + lectureId + ":TEACHER";
+            // Redis pub/sub - 메시지 전파
+            redisTemplate.convertAndSend(teacherChannel, originalMessageJson);
+
+            // 2-2. student 메시지 전송
+            // 메시지 구성
+            MessageRequestDTO.MessageDTO maskMessage = MessageRequestDTO.MessageDTO.builder()
+                    .lectureId(lectureId)
+                    .senderId(null)
+                    .senderName(null)
+                    .content(messageDTO.getContent())
+                    .build();
+
+            String maskMessageJson = objectMapper.writeValueAsString(maskMessage); // DTO -> JSON 직렬화
+
+            // Redis 채널 이름 지정: lecture:{lectureId}
+            String studentChannel = "lecture:" + lectureId + ":STUDENT";
+            // Redis pub/sub - 메시지 전파
+            redisTemplate.convertAndSend(studentChannel, maskMessageJson);
+
 
         } catch (Exception e){
             log.error("채팅 메시지 전송 실패",e);

--- a/backend/src/main/java/org/example/backend/global/redis/RedisConfig.java
+++ b/backend/src/main/java/org/example/backend/global/redis/RedisConfig.java
@@ -42,7 +42,7 @@ public class RedisConfig {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(redisConnectionFactory());
 
-        container.addMessageListener(redisMessageSubscriber, new PatternTopic("lecture:*:*"));
+        container.addMessageListener(redisMessageSubscriber, new PatternTopic("lecture:*"));
         return container;
     }
 }

--- a/backend/src/main/java/org/example/backend/global/redis/RedisConfig.java
+++ b/backend/src/main/java/org/example/backend/global/redis/RedisConfig.java
@@ -6,6 +6,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -33,10 +34,15 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisMessageListenerContainer redisMessageListenerContainer() {
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            RedisConnectionFactory redisConnectionFactory,
+            RedisMessageSubscriber redisMessageSubscriber
+    ) {
         // redis pub/sub 메시지 처리 listener
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(redisConnectionFactory());
+
+        container.addMessageListener(redisMessageSubscriber, new PatternTopic("lecture:*"));
         return container;
     }
 }

--- a/backend/src/main/java/org/example/backend/global/redis/RedisConfig.java
+++ b/backend/src/main/java/org/example/backend/global/redis/RedisConfig.java
@@ -42,7 +42,7 @@ public class RedisConfig {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(redisConnectionFactory());
 
-        container.addMessageListener(redisMessageSubscriber, new PatternTopic("lecture:*"));
+        container.addMessageListener(redisMessageSubscriber, new PatternTopic("lecture:*:*"));
         return container;
     }
 }

--- a/backend/src/main/java/org/example/backend/global/redis/RedisConfig.java
+++ b/backend/src/main/java/org/example/backend/global/redis/RedisConfig.java
@@ -6,6 +6,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -29,5 +30,13 @@ public class RedisConfig {
         redisTemplate.setKeySerializer(new StringRedisSerializer()); // key를 문자열로 직렬화
         redisTemplate.setValueSerializer(new StringRedisSerializer()); // value를 문자열로 직렬화
         return redisTemplate;
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer() {
+        // redis pub/sub 메시지 처리 listener
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(redisConnectionFactory());
+        return container;
     }
 }

--- a/backend/src/main/java/org/example/backend/global/redis/RedisMessageSubscriber.java
+++ b/backend/src/main/java/org/example/backend/global/redis/RedisMessageSubscriber.java
@@ -1,0 +1,45 @@
+package org.example.backend.global.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.backend.domain.question.dto.request.MessageRequestDTO;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+
+/**
+ * redis subscriber 역할을 수행하는 클래스
+ * redis pub/sub 채널로 메시지를 수신하면, 해당 메시지를 STOMP를 통해 web socket 구독자에게 브로드캐스트
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RedisMessageSubscriber implements MessageListener {
+
+    private final SimpMessageSendingOperations simpMessageSendingOperations;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * redis로부터 메시지를 수신했을 때 호출되는 메소드
+     *
+     * @param message redis에서 전달된 메시지(json 형태)
+     * @param pattern 구독중인 채널 패턴
+     */
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try{
+            String channel = new String(pattern);
+            String body = new String(message.getBody());
+
+            // JSON -> DTO 역직렬화
+            MessageRequestDTO.MessageDTO chatMessage = objectMapper.readValue(body, MessageRequestDTO.MessageDTO.class);
+
+            // subscriber에게 STOMP 메시지 전송
+            simpMessageSendingOperations.convertAndSend("/sub/lecture/"+ chatMessage.getLectureId(), chatMessage);
+        } catch (Exception e) {
+            log.error("Redis 메시지 수신 실패", e);
+        }
+    }
+}

--- a/backend/src/main/java/org/example/backend/global/redis/RedisMessageSubscriber.java
+++ b/backend/src/main/java/org/example/backend/global/redis/RedisMessageSubscriber.java
@@ -30,14 +30,22 @@ public class RedisMessageSubscriber implements MessageListener {
     @Override
     public void onMessage(Message message, byte[] pattern) {
         try{
-            String channel = new String(pattern);
+            String channel = new String(message.getChannel());
+
+            System.out.println(channel);
+            String[] parts = channel.split(":");
+            String lectureId = parts[1];
+            String role = parts[2];
+
+            System.out.println("lectureId = " + lectureId);
+            System.out.println("role = " + role);
             String body = new String(message.getBody());
 
             // JSON -> DTO 역직렬화
             MessageRequestDTO.MessageDTO chatMessage = objectMapper.readValue(body, MessageRequestDTO.MessageDTO.class);
 
             // subscriber에게 STOMP 메시지 전송
-            simpMessageSendingOperations.convertAndSend("/sub/lecture/"+ chatMessage.getLectureId(), chatMessage);
+            simpMessageSendingOperations.convertAndSend("/sub/lecture/"+ lectureId+"/"+role, chatMessage);
         } catch (Exception e) {
             log.error("Redis 메시지 수신 실패", e);
         }

--- a/backend/src/main/java/org/example/backend/global/redis/RedisMessageSubscriber.java
+++ b/backend/src/main/java/org/example/backend/global/redis/RedisMessageSubscriber.java
@@ -35,17 +35,14 @@ public class RedisMessageSubscriber implements MessageListener {
             System.out.println(channel);
             String[] parts = channel.split(":");
             String lectureId = parts[1];
-            String role = parts[2];
 
-            System.out.println("lectureId = " + lectureId);
-            System.out.println("role = " + role);
             String body = new String(message.getBody());
 
             // JSON -> DTO 역직렬화
             MessageRequestDTO.MessageDTO chatMessage = objectMapper.readValue(body, MessageRequestDTO.MessageDTO.class);
 
             // subscriber에게 STOMP 메시지 전송
-            simpMessageSendingOperations.convertAndSend("/sub/lecture/"+ lectureId+"/"+role, chatMessage);
+            simpMessageSendingOperations.convertAndSend("/sub/lecture/"+ lectureId, chatMessage);
         } catch (Exception e) {
             log.error("Redis 메시지 수신 실패", e);
         }

--- a/backend/src/main/java/org/example/backend/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/org/example/backend/global/security/config/SecurityConfig.java
@@ -14,6 +14,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -74,6 +75,7 @@ public class SecurityConfig {
 //                        .anyRequest().permitAll()
                         .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                         .requestMatchers("/actuator/health").permitAll()
+                        .requestMatchers("/ws-connect/**").permitAll()
                         .requestMatchers("/api/users","/api/users/verify-email","/api/users/login","/api/users/password/temp").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(new FilterExceptionHandler(), LogoutFilter.class) // 예외처리 필터
@@ -97,5 +99,12 @@ public class SecurityConfig {
         source.registerCorsConfiguration("/**", configuration);
 
         return source;
+    }
+
+    // web socket 허용
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return (web) -> web.ignoring()
+                .requestMatchers("/ws-connect/**");
     }
 }

--- a/backend/src/main/java/org/example/backend/global/security/filter/JWTFilter.java
+++ b/backend/src/main/java/org/example/backend/global/security/filter/JWTFilter.java
@@ -41,7 +41,8 @@ public class JWTFilter extends OncePerRequestFilter {
                 uri.equals("/api/users")||
                 uri.equals("/api/users/password/temp")||
                 uri.equals("/api/users/verify-email")||
-                uri.equals("/api/users/refresh")) {
+                uri.equals("/api/users/refresh")||
+                uri.startsWith("/ws-connect")) {
             filterChain.doFilter(request, response);
             return;
         }
@@ -55,14 +56,14 @@ public class JWTFilter extends OncePerRequestFilter {
         // request에서 Authorization 헤더를 찾음
         String authorization = request.getHeader("Authorization");
 
-//        // Authorization 헤더 검증
-//        if(authorization == null || !authorization.startsWith("Bearer ")){
-//            System.out.println("token null or invalid");
-//            setErrorResponse(response, UserErrorCode._TOKEN_MISSING);
-//
-//            // 조건이 해당되면 메소드 종료
-//            return;
-//        }
+        // Authorization 헤더 검증
+        if(authorization == null || !authorization.startsWith("Bearer ")){
+            System.out.println("token null or invalid");
+            setErrorResponse(response, UserErrorCode._TOKEN_MISSING);
+
+            // 조건이 해당되면 메소드 종료
+            return;
+        }
 
         // Bearer 제외하고 토큰만 획득
         String token = authorization.substring(7);

--- a/backend/src/main/java/org/example/backend/global/websocket/StompChannelInterceptor.java
+++ b/backend/src/main/java/org/example/backend/global/websocket/StompChannelInterceptor.java
@@ -1,0 +1,47 @@
+package org.example.backend.global.websocket;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.backend.global.security.token.JWTUtil;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class StompChannelInterceptor implements ChannelInterceptor {
+
+    private final JWTUtil jwtUtil;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        log.info("CONNECT 헤더: {}", accessor.toNativeHeaderMap());
+
+        if(accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
+            log.info("WebSocket CONNECT 요청 도착");
+
+            String token = accessor.getFirstNativeHeader("Authorization");
+
+            if(token != null && token.startsWith("Bearer ")) {
+                token = token.substring(7);
+                UUID userId = jwtUtil.getUserId(token);
+                String role = jwtUtil.getRole(token);
+
+                log.info("✅ STOMP 연결 토큰 검증 성공: userId={}, role={}", userId, role);
+                accessor.setUser(new StompPrincipal(userId, role));
+            }else {
+                log.warn("❌ STOMP 연결 시 토큰 누락 또는 형식 오류: {}", token);
+            }
+        }
+        return message;
+    }
+
+}

--- a/backend/src/main/java/org/example/backend/global/websocket/StompPrincipal.java
+++ b/backend/src/main/java/org/example/backend/global/websocket/StompPrincipal.java
@@ -1,0 +1,11 @@
+package org.example.backend.global.websocket;
+
+
+import java.security.Principal;
+import java.util.UUID;
+public record StompPrincipal(UUID userId, String role) implements Principal {
+    @Override
+    public String getName() {
+        return userId.toString();
+    }
+}

--- a/backend/src/main/java/org/example/backend/global/websocket/WebSocketConfig.java
+++ b/backend/src/main/java/org/example/backend/global/websocket/WebSocketConfig.java
@@ -1,0 +1,23 @@
+package org.example.backend.global.websocket;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // 핸드쉐이크
+        registry.addEndpoint("/ws-connect").setAllowedOrigins("*").withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/sub"); // 메시지 받을 경로
+        registry.setApplicationDestinationPrefixes("/pub"); // 메시지 보낼 경로
+    }
+}

--- a/backend/src/main/java/org/example/backend/global/websocket/WebSocketConfig.java
+++ b/backend/src/main/java/org/example/backend/global/websocket/WebSocketConfig.java
@@ -12,7 +12,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         // 핸드쉐이크
-        registry.addEndpoint("/ws-connect").setAllowedOrigins("*").withSockJS();
+        registry.addEndpoint("/ws-connect").setAllowedOriginPatterns("*").withSockJS();
     }
 
     @Override

--- a/backend/src/main/java/org/example/backend/global/websocket/WebSocketConfig.java
+++ b/backend/src/main/java/org/example/backend/global/websocket/WebSocketConfig.java
@@ -1,6 +1,8 @@
 package org.example.backend.global.websocket;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -8,7 +10,16 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final StompChannelInterceptor stompChannelInterceptor;
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        // 인터셉터 등록
+        registration.interceptors(stompChannelInterceptor);
+    }
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         // 핸드쉐이크


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#304 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
로직 흐름
**handshake**
1. 클라이언트가 /ws-connect로 web socket 연결 요청
2. WebSocketConfig를 통해 STOMP 프로토콜로 업그레이드 및 Handshake 수행
3. 이후 클라이언트는 /pub으로 메시지를 발행하고, /sub을 통해 메시지 수신 가능

**메시지 송수신과정**
1. 클라이언트에서 /pub/lecture/{lectureId}로 메시지 전송
2. 서버에서 수신 후, Redis Pub/Sub으로 모든 구독자에게 브로드캐스트 & redis list에 채팅 내용 저장
3. Redis → RedisMessageSubscriber를 통해 메시지를 다시 브로드캐스트
4. STOMP를 통해 /sub/lecture/{lectureId}로 메시지가 전달되어 클라이언트에서 수신

주요 파일 설명
1. WebSocketConfig: WebSocket 및 STOMP 기본 설정 (엔드포인트 등록, 브로커 경로 지정)
2. StompChannelInterceptor: STOMP 연결 시 인터셉트하여 JWT 인증 및 사용자 정보 추출
3. StompPrincipal: 인증된 사용자 정보를 WebSocket 세션에 저장하기 위한 커스텀 Principal 객체
4. ChatController: /pub/lecture/{lectureId}로 전달된 메시지를 수신
5. ChatService: 수신된 메시지를 Redis에 저장하고 Redis 채널로 발행하는 로직 처리
6. RedisMessageSubscriber: Redis로부터 발행된 메시지를 수신 → STOMP를 통해 해당 채널 구독자에게 메시지 전파


### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
추후 이슈에서 이전 내용 불러오기와 종료 이후에 RDB에 저장하는 로직 구현하겠습니다.

### 📷 스크린샷 또는 GIF
X
