### PR TITLE
📦 CD 파이프라인 수정

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -100,6 +100,20 @@ jobs:
             NEXT_PUBLIC_API_BASE_URL=${{secrets.NEXT_PUBLIC_API_BASE_URL}}
             NEXT_PUBLIC_WS_URL=${{secrets.NEXT_PUBLIC_WS_URL}}
             EOF
+
+      - name: Create .env for docker compose
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            mkdir -p /home/ubuntu/classlog
+            cat > /home/ubuntu/classlog/.env <<EOF
+            DOCKERHUB_USERNAME=${{ secrets.DOCKER_USERNAME }}
+            IMAGE_TAG=${{ github.sha }}
+            EOF
+
       - name: Deploy containers
         uses: appleboy/ssh-action@v1.0.3
         with:
@@ -107,11 +121,7 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
           script: |
-            cd /home/ubuntu/classlog
-            export DOCKERHUB_USERNAME="${{ secrets.DOCKER_USERNAME }}"
-            export IMAGE_TAG="${{ github.sha }}"
-            
-            echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
+            echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{DOCKERHUB_USERNAME}}" --password-stdin
             docker compose down
             docker compose pull
             docker compose up -d


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#356

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
GitHub Actions에서 Deploy 단계 시 export DOCKERHUB_USERNAME, export IMAGE_TAG를 사용했는데 이 값들이 SSH 세션 내에서만 유효해 서버 재부팅 후 사라졌습니다.
SSH 세션에서 export한 환경변수는 서버 재부팅 후 Docker Compose가 변수를 읽지 못합니다.
IMAGE_TAG는 매 배포 시점의 ${{ github.sha }} 값으로 변하기 때문에 고정 .env에 넣기도 곤란해서 매 배포 시 최신 SHA와 Docker Hub 계정으로 /home/ubuntu/classlog/.env를 갱신하도록 수정했습니다.

### 🌀 PR Point

X

### 🍰 참고사항

X

### 📷 스크린샷 또는 GIF
X
