### PR TITLE
✨ Feat/#365 퀴즈 생성 로직 변경, 퀴즈 문제 확인 페이지 추가

### DIFF
--- a/backend/src/main/java/org/example/backend/domain/quiz/controller/QuizController.java
+++ b/backend/src/main/java/org/example/backend/domain/quiz/controller/QuizController.java
@@ -26,41 +26,41 @@ public class QuizController {
     private final QuizService quizService;
     private final QuizEditService quizEditService;
 
-    // 퀴즈 생성
-    @PostMapping("/{lectureId}/create")
-    public ResponseEntity<ApiResponse<QuizResponseDTO>> generateQuiz(@PathVariable("lectureId") UUID lectureId,
-                                                                     @RequestBody QuizRequestDTO request) {
-        try {
-            QuizResponseDTO response = quizService.generateQuiz(lectureId, request, false);
-            return ResponseEntity.ok(ApiResponse.onSuccess(response));
-        } catch (QuizException e) {
-            return ResponseEntity
-                    .status(e.getErrorCode().getReasonHttpStatus().getHttpStatus())
-                    .body(ApiResponse.onFailure(e.getErrorCode()));
-        } catch (Exception e) {
-            return ResponseEntity
-                    .status(FailureCode._INTERNAL_SERVER_ERROR.getReasonHttpStatus().getHttpStatus())
-                    .body(ApiResponse.onFailure(FailureCode._INTERNAL_SERVER_ERROR));
-        }
-    }
-
-    // 퀴즈 재생성
-    @PostMapping("/{lectureId}/re-create")
-    public ResponseEntity<ApiResponse<QuizResponseDTO>> regenerateQuiz(@PathVariable("lectureId") UUID lectureId,
-                                                                       @RequestBody QuizRequestDTO request) {
-        try {
-            QuizResponseDTO response = quizService.generateQuiz(lectureId, request, true);
-            return ResponseEntity.ok(ApiResponse.onSuccess(response));
-        } catch (QuizException e) {
-            return ResponseEntity
-                    .status(e.getErrorCode().getReasonHttpStatus().getHttpStatus())
-                    .body(ApiResponse.onFailure(e.getErrorCode()));
-        } catch (Exception e) {
-            return ResponseEntity
-                    .status(FailureCode._INTERNAL_SERVER_ERROR.getReasonHttpStatus().getHttpStatus())
-                    .body(ApiResponse.onFailure(FailureCode._INTERNAL_SERVER_ERROR));
-        }
-    }
+//    // 퀴즈 생성
+//    @PostMapping("/{lectureId}/create")
+//    public ResponseEntity<ApiResponse<QuizResponseDTO>> generateQuiz(@PathVariable("lectureId") UUID lectureId,
+//                                                                     @RequestBody QuizRequestDTO request) {
+//        try {
+//            QuizResponseDTO response = quizService.generateQuiz(lectureId, request, false);
+//            return ResponseEntity.ok(ApiResponse.onSuccess(response));
+//        } catch (QuizException e) {
+//            return ResponseEntity
+//                    .status(e.getErrorCode().getReasonHttpStatus().getHttpStatus())
+//                    .body(ApiResponse.onFailure(e.getErrorCode()));
+//        } catch (Exception e) {
+//            return ResponseEntity
+//                    .status(FailureCode._INTERNAL_SERVER_ERROR.getReasonHttpStatus().getHttpStatus())
+//                    .body(ApiResponse.onFailure(FailureCode._INTERNAL_SERVER_ERROR));
+//        }
+//    }
+//
+//    // 퀴즈 재생성
+//    @PostMapping("/{lectureId}/re-create")
+//    public ResponseEntity<ApiResponse<QuizResponseDTO>> regenerateQuiz(@PathVariable("lectureId") UUID lectureId,
+//                                                                       @RequestBody QuizRequestDTO request) {
+//        try {
+//            QuizResponseDTO response = quizService.generateQuiz(lectureId, request, true);
+//            return ResponseEntity.ok(ApiResponse.onSuccess(response));
+//        } catch (QuizException e) {
+//            return ResponseEntity
+//                    .status(e.getErrorCode().getReasonHttpStatus().getHttpStatus())
+//                    .body(ApiResponse.onFailure(e.getErrorCode()));
+//        } catch (Exception e) {
+//            return ResponseEntity
+//                    .status(FailureCode._INTERNAL_SERVER_ERROR.getReasonHttpStatus().getHttpStatus())
+//                    .body(ApiResponse.onFailure(FailureCode._INTERNAL_SERVER_ERROR));
+//        }
+//    }
 
     // 퀴즈 저장
     @PostMapping("/{lectureId}/save")

--- a/backend/src/main/java/org/example/backend/domain/quiz/service/QuizServiceImpl.java
+++ b/backend/src/main/java/org/example/backend/domain/quiz/service/QuizServiceImpl.java
@@ -24,6 +24,7 @@ import org.example.backend.domain.quiz.exception.QuizErrorCode;
 import org.example.backend.domain.quiz.exception.QuizException;
 import org.example.backend.domain.quiz.repository.QuizRepository;
 import org.example.backend.domain.quizAnswer.repository.QuizAnswerRepository;
+import org.example.backend.domain.quizList.repository.QuizListRepository;
 import org.example.backend.domain.user.entity.Role;
 import org.example.backend.global.security.auth.CustomSecurityUtil;
 import org.example.backend.infra.langchain.LangChainClient;
@@ -56,6 +57,7 @@ public class QuizServiceImpl implements QuizService {
     private final QuizAnswerRepository quizAnswerRepository;
     private final CustomSecurityUtil customSecurityUtil;
     private final QuizConverter quizConverter;
+    private final QuizListRepository quizListRepository;
 
     private final TaskScheduler taskScheduler;
     private final NotificationService notificationService;
@@ -183,6 +185,7 @@ public class QuizServiceImpl implements QuizService {
         }
         scheduleQuizAnswerUploadNotification(lecture);
 
+        quizListRepository.resetAllUsedFlags();
 
         return QuizSaveResponseDTO.builder()
                 .lectureId(lectureId)
@@ -190,6 +193,7 @@ public class QuizServiceImpl implements QuizService {
                 .quizIds(savedQuizIds)
                 .build();
     }
+
     private void scheduleQuizAnswerUploadNotification(Lecture lecture) {
         // 현재 시간 기준으로 "오늘 밤 12시(자정)" 계산
         LocalDateTime midnight = LocalDate.now()

--- a/backend/src/main/java/org/example/backend/domain/quiz/service/QuizServiceImpl.java
+++ b/backend/src/main/java/org/example/backend/domain/quiz/service/QuizServiceImpl.java
@@ -131,6 +131,7 @@ public class QuizServiceImpl implements QuizService {
 
     // 퀴즈 저장
     @Override
+    @Transactional
     public QuizSaveResponseDTO saveQuiz(UUID lectureId, QuizSaveRequestDTO request) {
 
         Role role = customSecurityUtil.getUserRole();

--- a/backend/src/main/java/org/example/backend/domain/quizList/controller/QuizListController.java
+++ b/backend/src/main/java/org/example/backend/domain/quizList/controller/QuizListController.java
@@ -1,0 +1,57 @@
+package org.example.backend.domain.quizList.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.domain.quiz.dto.response.QuizResponseDTO;
+import org.example.backend.domain.quiz.exception.QuizException;
+import org.example.backend.domain.quizList.service.QuizListService;
+import org.example.backend.global.ApiResponse;
+import org.example.backend.global.code.base.FailureCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/quizzes")
+@RequiredArgsConstructor
+public class QuizListController {
+
+    private final QuizListService quizListService;
+
+    @PostMapping("/{lectureId}/create")
+    public ResponseEntity<ApiResponse<QuizResponseDTO>> createRandomQuiz(
+            @PathVariable("lectureId") UUID lectureId) {
+        try {
+            QuizResponseDTO response = quizListService.createRandomQuizSet(lectureId);
+            return ResponseEntity.ok(ApiResponse.onSuccess(response));
+        } catch (QuizException e) {
+            return ResponseEntity
+                    .status(e.getErrorCode().getReasonHttpStatus().getHttpStatus())
+                    .body(ApiResponse.onFailure(e.getErrorCode()));
+        } catch (Exception e) {
+            return ResponseEntity
+                    .status(FailureCode._INTERNAL_SERVER_ERROR.getReasonHttpStatus().getHttpStatus())
+                    .body(ApiResponse.onFailure(FailureCode._INTERNAL_SERVER_ERROR));
+        }
+    }
+
+    @PostMapping("/{lectureId}/re-create")
+    public ResponseEntity<ApiResponse<QuizResponseDTO>> recreateRandomQuiz(
+            @PathVariable("lectureId") UUID lectureId) {
+        try {
+            QuizResponseDTO response = quizListService.recreateRandomQuizSet(lectureId);
+            return ResponseEntity.ok(ApiResponse.onSuccess(response));
+        } catch (QuizException e) {
+            return ResponseEntity
+                    .status(e.getErrorCode().getReasonHttpStatus().getHttpStatus())
+                    .body(ApiResponse.onFailure(e.getErrorCode()));
+        } catch (Exception e) {
+            return ResponseEntity
+                    .status(FailureCode._INTERNAL_SERVER_ERROR.getReasonHttpStatus().getHttpStatus())
+                    .body(ApiResponse.onFailure(FailureCode._INTERNAL_SERVER_ERROR));
+        }
+    }
+}

--- a/backend/src/main/java/org/example/backend/domain/quizList/entity/QuizList.java
+++ b/backend/src/main/java/org/example/backend/domain/quizList/entity/QuizList.java
@@ -1,0 +1,56 @@
+package org.example.backend.domain.quizList.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.backend.domain.lecture.entity.Lecture;
+import org.example.backend.domain.quiz.entity.QuizType;
+import org.example.backend.domain.quizListOptions.entity.QuizListOptions;
+import org.example.backend.global.entitiy.BaseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "quiz_list")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QuizList extends BaseEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "lecture_id", nullable = false)
+    private Lecture lecture;
+
+    @Column(nullable = false)
+    private String quiz;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private QuizType type;
+
+    @Column(nullable = false)
+    private String solution;
+
+    @Column(name = "quiz_order", nullable = false)
+    private Integer quizOrder;
+
+    @Column(name = "used", length = 1, nullable = false, columnDefinition = "CHAR(1) DEFAULT 'F'")
+    private String used;
+
+    @OneToMany(mappedBy = "quizListId", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<QuizListOptions> quizListOptions = new ArrayList<>();
+
+    public void update(String quizBody, String solution, QuizType type) {
+        this.quiz = quizBody;
+        this.solution = solution;
+        this.type = type;
+    }
+}
+

--- a/backend/src/main/java/org/example/backend/domain/quizList/repository/QuizListRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/quizList/repository/QuizListRepository.java
@@ -1,0 +1,45 @@
+package org.example.backend.domain.quizList.repository;
+
+import org.example.backend.domain.quizList.entity.QuizList;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface QuizListRepository extends JpaRepository<QuizList, UUID> {
+
+    @Query(value = """
+            SELECT * FROM quiz_list
+            WHERE lecture_id = :lectureId
+              AND type = :type
+              AND used = 'F'
+            ORDER BY RAND()
+            LIMIT :limit
+            """, nativeQuery = true)
+    List<QuizList> findRandomByLectureIdAndType(
+            @Param("lectureId") UUID lectureId,
+            @Param("type") String type,
+            @Param("limit") int limit);
+
+    @Query(value = """
+            SELECT * FROM quiz_list
+            WHERE lecture_id = :lectureId
+              AND type = :type
+              AND used != 'T'
+            ORDER BY RAND()
+            LIMIT :limit
+            """, nativeQuery = true)
+    List<QuizList> findRandomByLectureIdAndTypeExcludeUsed(
+            @Param("lectureId") UUID lectureId,
+            @Param("type") String type,
+            @Param("limit") int limit);
+
+    @Modifying
+    @Query(value = "UPDATE quiz_list SET used = 'F'", nativeQuery = true)
+    void resetAllUsedFlags();
+}

--- a/backend/src/main/java/org/example/backend/domain/quizList/service/QuizListService.java
+++ b/backend/src/main/java/org/example/backend/domain/quizList/service/QuizListService.java
@@ -1,0 +1,11 @@
+package org.example.backend.domain.quizList.service;
+
+
+import org.example.backend.domain.quiz.dto.response.QuizResponseDTO;
+
+import java.util.UUID;
+
+public interface QuizListService {
+    QuizResponseDTO createRandomQuizSet(UUID lectureId);
+    QuizResponseDTO recreateRandomQuizSet(UUID lectureId);
+}

--- a/backend/src/main/java/org/example/backend/domain/quizList/service/QuizListServiceImpl.java
+++ b/backend/src/main/java/org/example/backend/domain/quizList/service/QuizListServiceImpl.java
@@ -1,0 +1,130 @@
+package org.example.backend.domain.quizList.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.domain.lecture.entity.Lecture;
+import org.example.backend.domain.lecture.repository.LectureRepository;
+import org.example.backend.domain.quiz.dto.response.QuizResponseDTO;
+import org.example.backend.domain.quiz.entity.QuizType;
+import org.example.backend.domain.quiz.exception.QuizErrorCode;
+import org.example.backend.domain.quiz.exception.QuizException;
+import org.example.backend.domain.quizList.entity.QuizList;
+import org.example.backend.domain.quizList.repository.QuizListRepository;
+import org.example.backend.domain.quizListOptions.entity.QuizListOptions;
+import org.example.backend.domain.quizListOptions.repository.QuizListOptionsRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class QuizListServiceImpl implements QuizListService {
+
+    private final LectureRepository lectureRepository;
+    private final QuizListRepository quizListRepository;
+    private final QuizListOptionsRepository quizListOptionsRepository;
+
+    @Override
+    @Transactional
+    public QuizResponseDTO createRandomQuizSet(UUID lectureId) {
+
+        Lecture lecture = lectureRepository.findById(lectureId)
+                .orElseThrow(() -> new QuizException(QuizErrorCode.LECTURE_NOT_FOUND));
+
+        List<QuizList> multipleChoiceList = quizListRepository.findRandomByLectureIdAndType(lectureId, QuizType.MULTIPLE_CHOICE.name(), 2);
+        List<QuizList> shortAnswerList = quizListRepository.findRandomByLectureIdAndType(lectureId, QuizType.SHORT_ANSWER.name(), 1);
+        List<QuizList> trueFalseList = quizListRepository.findRandomByLectureIdAndType(lectureId, QuizType.TRUE_FALSE.name(), 1);
+
+        List<QuizList> allSelected = new ArrayList<>();
+        allSelected.addAll(multipleChoiceList);
+        allSelected.addAll(shortAnswerList);
+        allSelected.addAll(trueFalseList);
+
+        if (allSelected.isEmpty()) {
+            throw new QuizException(QuizErrorCode.QUIZ_NOT_GENERATED_YET);
+        }
+
+        allSelected.forEach(quiz -> quiz.setUsed("T"));
+        quizListRepository.saveAll(allSelected);
+
+        List<QuizResponseDTO.QuizDTO> quizDTOs = allSelected.stream()
+                .map(quiz -> {
+                    List<String> options = new ArrayList<>();
+
+                    if (quiz.getType() == QuizType.MULTIPLE_CHOICE) {
+                        options = quizListOptionsRepository.findByQuizListId_Id(quiz.getId())
+                                .stream()
+                                .map(QuizListOptions::getText)
+                                .toList();
+                    }
+
+                    String camelType = QuizType.toCamelCase(quiz.getType().name());
+
+                    return QuizResponseDTO.QuizDTO.builder()
+                            .quizBody(quiz.getQuiz())
+                            .solution(quiz.getSolution())
+                            .type(camelType) // e.g. "multipleChoice", "shortAnswer", "trueFalse"
+                            .options(options)
+                            .build();
+                })
+                .toList();
+
+        return QuizResponseDTO.builder()
+                .lectureId(lectureId)
+                .quizzes(quizDTOs)
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public QuizResponseDTO recreateRandomQuizSet(UUID lectureId) {
+
+        Lecture lecture = lectureRepository.findById(lectureId)
+                .orElseThrow(() -> new QuizException(QuizErrorCode.LECTURE_NOT_FOUND));
+
+        List<QuizList> multipleChoiceList = quizListRepository.findRandomByLectureIdAndTypeExcludeUsed(lectureId, QuizType.MULTIPLE_CHOICE.name(), 2);
+        List<QuizList> shortAnswerList = quizListRepository.findRandomByLectureIdAndTypeExcludeUsed(lectureId, QuizType.SHORT_ANSWER.name(), 1);
+        List<QuizList> trueFalseList = quizListRepository.findRandomByLectureIdAndTypeExcludeUsed(lectureId, QuizType.TRUE_FALSE.name(), 1);
+
+        List<QuizList> allSelected = new ArrayList<>();
+        allSelected.addAll(multipleChoiceList);
+        allSelected.addAll(shortAnswerList);
+        allSelected.addAll(trueFalseList);
+
+        if (allSelected.isEmpty()) {
+            throw new QuizException(QuizErrorCode.QUIZ_NOT_GENERATED_YET);
+        }
+
+        allSelected.forEach(quiz -> quiz.setUsed("T"));
+        quizListRepository.saveAll(allSelected);
+
+        List<QuizResponseDTO.QuizDTO> quizDTOs = allSelected.stream()
+                .map(quiz -> {
+                    List<String> options = new ArrayList<>();
+
+                    if (quiz.getType() == QuizType.MULTIPLE_CHOICE) {
+                        options = quizListOptionsRepository.findByQuizListId_Id(quiz.getId())
+                                .stream()
+                                .map(QuizListOptions::getText)
+                                .toList();
+                    }
+
+                    String camelType = QuizType.toCamelCase(quiz.getType().name());
+
+                    return QuizResponseDTO.QuizDTO.builder()
+                            .quizBody(quiz.getQuiz())
+                            .solution(quiz.getSolution())
+                            .type(camelType)
+                            .options(options)
+                            .build();
+                })
+                .toList();
+
+        return QuizResponseDTO.builder()
+                .lectureId(lectureId)
+                .quizzes(quizDTOs)
+                .build();
+    }
+}

--- a/backend/src/main/java/org/example/backend/domain/quizList/service/QuizListServiceImpl.java
+++ b/backend/src/main/java/org/example/backend/domain/quizList/service/QuizListServiceImpl.java
@@ -122,6 +122,8 @@ public class QuizListServiceImpl implements QuizListService {
                 })
                 .toList();
 
+        quizListRepository.resetAllUsedFlags();
+
         return QuizResponseDTO.builder()
                 .lectureId(lectureId)
                 .quizzes(quizDTOs)

--- a/backend/src/main/java/org/example/backend/domain/quizListOptions/entity/QuizListOptions.java
+++ b/backend/src/main/java/org/example/backend/domain/quizListOptions/entity/QuizListOptions.java
@@ -1,0 +1,36 @@
+package org.example.backend.domain.quizListOptions.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.backend.domain.quizList.entity.QuizList;
+import org.example.backend.global.entitiy.BaseEntity;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "quiz_list_options")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QuizListOptions extends BaseEntity {
+    @Id
+    @GeneratedValue
+    @Column(name = "id", nullable = false)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "quiz_list_id", nullable = false)
+    private QuizList quizListId;
+
+    @Column(name = "text", nullable = false)
+    private String text;
+
+    @Column(name = "option_order")
+    private int optionOrder;
+
+    public void updateText(String text) {
+        this.text = text;
+    }
+}
+

--- a/backend/src/main/java/org/example/backend/domain/quizListOptions/repository/QuizListOptionsRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/quizListOptions/repository/QuizListOptionsRepository.java
@@ -1,0 +1,13 @@
+package org.example.backend.domain.quizListOptions.repository;
+
+import org.example.backend.domain.quizListOptions.entity.QuizListOptions;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface QuizListOptionsRepository extends JpaRepository<QuizListOptions, UUID> {
+    List<QuizListOptions> findByQuizListId_Id(UUID quizListId);
+}

--- a/frontend/api/quizzes/fetchQuizDetailStat.ts
+++ b/frontend/api/quizzes/fetchQuizDetailStat.ts
@@ -1,0 +1,19 @@
+import axios from "axios";
+import { axiosInstance } from "@/api/axiosInstance";
+import { ENDPOINTS } from "@/constants/endpoints";
+import { ApiResponse } from "@/types/apiResponseTypes";
+import { fetchQuizDetailStatResult } from "@/types/quizzes/fetchQuizDetailStatTypes";
+
+export async function fetchQuizDetailStat(lectureId: string) {
+  try {
+    const response = await axiosInstance.get<
+      ApiResponse<fetchQuizDetailStatResult>
+    >(ENDPOINTS.QUIZZES.GET_DETAIL_STAT(lectureId));
+    return response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error) && error.response) {
+      return error.response.data as ApiResponse<fetchQuizDetailStatResult>;
+    }
+    throw error;
+  }
+}

--- a/frontend/api/quizzes/fetchQuizForDashboard.ts
+++ b/frontend/api/quizzes/fetchQuizForDashboard.ts
@@ -1,0 +1,19 @@
+import axios from "axios";
+import { axiosInstance } from "@/api/axiosInstance";
+import { ENDPOINTS } from "@/constants/endpoints";
+import { ApiResponse } from "@/types/apiResponseTypes";
+import { fetchQuizForDashboardResult } from "@/types/quizzes/fetchQuizForDashboardTypes";
+
+export async function fetchQuizForDashboard(lectureId: string) {
+  try {
+    const response = await axiosInstance.get<
+      ApiResponse<fetchQuizForDashboardResult>
+    >(ENDPOINTS.QUIZZES.GET_FOR_DASHBOARD(lectureId));
+    return response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error) && error.response) {
+      return error.response.data as ApiResponse<fetchQuizForDashboardResult>;
+    }
+    throw error;
+  }
+}

--- a/frontend/api/quizzes/fetchQuizInfo.ts
+++ b/frontend/api/quizzes/fetchQuizInfo.ts
@@ -1,0 +1,19 @@
+import axios from "axios";
+import { axiosInstance } from "@/api/axiosInstance";
+import { ENDPOINTS } from "@/constants/endpoints";
+import { ApiResponse } from "@/types/apiResponseTypes";
+import { fetchQuizInfoResult } from "@/types/quizzes/fetchQuizInfoTypes";
+
+export async function fetchQuizInfo(lectureId: string) {
+  try {
+    const response = await axiosInstance.get<ApiResponse<fetchQuizInfoResult>>(
+      ENDPOINTS.QUIZZES.GET_INFO(lectureId)
+    );
+    return response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error) && error.response) {
+      return error.response.data as ApiResponse<fetchQuizInfoResult>;
+    }
+    throw error;
+  }
+}

--- a/frontend/api/quizzes/fetchSubmitList.ts
+++ b/frontend/api/quizzes/fetchSubmitList.ts
@@ -1,0 +1,19 @@
+import axios from "axios";
+import { axiosInstance } from "@/api/axiosInstance";
+import { ENDPOINTS } from "@/constants/endpoints";
+import { ApiResponse } from "@/types/apiResponseTypes";
+import { fetchQuizSubmitListResult } from "@/types/quizzes/fetchSubmitListTypes";
+
+export async function fetchSubmitList(lectureId: string) {
+  try {
+    const response = await axiosInstance.get<
+      ApiResponse<fetchQuizSubmitListResult>
+    >(ENDPOINTS.QUIZZES.GET_SUBMIT_LIST(lectureId));
+    return response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error) && error.response) {
+      return error.response.data as ApiResponse<fetchQuizSubmitListResult>;
+    }
+    throw error;
+  }
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,4 +1,40 @@
 import "./globals.scss";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "ClassLog",
+  manifest: "./manifest.webmanifest",
+  themeColor: "#ffffff",
+  appleWebApp: {
+    capable: true,
+    title: "ClassLog",
+    statusBarStyle: "default",
+  },
+  icons: {
+    apple: [
+      {
+        url: "/favicon/apple-touch-icon.png",
+        sizes: "180x180",
+        type: "image/png",
+      },
+    ],
+    icon: [
+      {
+        url: "/favicon/favicon-96x96.png",
+        sizes: "96x96",
+        type: "image/png",
+      },
+      {
+        url: "/favicon/favicon.svg",
+        type: "image/svg+xml",
+      },
+      {
+        url: "/favicon/favicon.ico",
+        type: "image/x-icon",
+      },
+    ],
+  },
+};
 
 export default function RootLayout({
   children,
@@ -7,25 +43,6 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <head>
-        <link rel="manifest" href="./manifest.webmanifest" />
-        <title>ClassLog</title>
-        <meta name="theme-color" content="#ffffff" />
-        <meta name="apple-mobile-web-app-title" content="ClassLog" />
-        <link
-          rel="apple-touch-icon"
-          href="/favicon/apple-touch-icon.png"
-          sizes="180x180"
-        />
-        <link
-          rel="icon"
-          type="image/png"
-          href="/favicon/favicon-96x96.png"
-          sizes="96x96"
-        />
-        <link rel="icon" type="image/svg+xml" href="/favicon/favicon.svg" />
-        <link rel="shortcut icon" href="/favicon/favicon.ico" />
-      </head>
       {children}
     </html>
   );

--- a/frontend/app/teacher/layout.tsx
+++ b/frontend/app/teacher/layout.tsx
@@ -44,12 +44,16 @@ export default function TeacherLayout({
   const showSidebar = currentRoute?.sidebarType === SiderbarType.DEFAULT;
   const showHeader = currentRoute?.headerType !== TeacherHeaderType.NONE;
 
+  const bodyClassName = [
+    "teacher-body",
+    showSidebar && "show-sidebar",
+    showHeader && "show-header",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
-    <body
-      className={`teacher-body ${showSidebar ? "show-sidebar" : ""} ${
-        showHeader ? "show-header" : ""
-      }`}
-    >
+    <body className={bodyClassName}>
       {showSidebar && <SideBar />}
       {renderHeader()}
       <div className="content">{children}</div>

--- a/frontend/app/teacher/quiz-dashboard/[lectureId]/_components/DashboardContainer/DashboardContainer.tsx
+++ b/frontend/app/teacher/quiz-dashboard/[lectureId]/_components/DashboardContainer/DashboardContainer.tsx
@@ -1,113 +1,32 @@
 "use client";
-import React from "react";
+
+import React, { useEffect, useState } from "react";
 import styles from "./DashboardContainer.module.scss";
 import QuizInfo from "../QuizInfo/QuizInfo";
 import QuizSubmitList from "../QuizSubmitList/QuizSubmitList";
 import QuizList from "../QuizList/QuizList";
 import StatisticsContainer from "../StatisticsContainer/StatisticsContainer";
-
-type Quiz =
-  | {
-      quizId: string;
-      quizOrder: number;
-      type: "multipleChoice";
-      quizBody: string;
-      correctRate: number;
-      solution: string;
-      options: Array<{ optionOrder: number; option: string; count: number }>;
-    }
-  | {
-      quizId: string;
-      quizOrder: number;
-      type: "trueFalse";
-      quizBody: string;
-      correctRate: number;
-      solution: string;
-      options: Array<{ optionOrder: null; option: string; count: number }>;
-    }
-  | {
-      quizId: string;
-      quizOrder: number;
-      type: "shortAnswer";
-      quizBody: string;
-      correctRate: number;
-      solution: string;
-      count: number;
-    };
+import { fetchQuizForDashboardResult } from "@/types/quizzes/fetchQuizForDashboardTypes";
+import { fetchQuizForDashboard } from "@/api/quizzes/fetchQuizForDashboard";
+import { useParams } from "next/navigation";
 
 export default function DashboardContainer() {
-  const statData: {
-    totalQuizCount: number;
-    averageCorrectRate: number;
-    quizList: Quiz[];
-  } = {
-    totalQuizCount: 4,
-    averageCorrectRate: 57.5,
-    quizList: [
-      {
-        quizId: "qz-001",
-        quizOrder: 1,
-        type: "multipleChoice",
-        quizBody: "앙상블 학습의 주요 목적 중 하나로 올바른 설명을 고르세요.",
-        correctRate: 70.0,
-        solution: "여러 모델을 결합해 오류를 줄이기 위해",
-        options: [
-          {
-            optionOrder: 1,
-            option: "여러 모델을 결합해 오류를 줄이기 위해",
-            count: 7,
-          },
-          {
-            optionOrder: 2,
-            option: "하나의 모델 성능을 극단적으로 향상시키기 위해",
-            count: 2,
-          },
-          {
-            optionOrder: 3,
-            option: "모델의 학습 속도를 높이기 위해",
-            count: 0,
-          },
-          {
-            optionOrder: 4,
-            option: "데이터를 줄여 모델을 간소화하기 위해",
-            count: 1,
-          },
-        ],
-      },
-      {
-        quizId: "qz-002",
-        quizOrder: 2,
-        type: "trueFalse",
-        quizBody: "Random Forest는 개별 트리의 가지치기를 수행하지 않는다.",
-        correctRate: 80.0,
-        solution: "O",
-        options: [
-          { optionOrder: null, option: "O", count: 8 },
-          { optionOrder: null, option: "X", count: 2 },
-        ],
-      },
-      {
-        quizId: "qz-003",
-        quizOrder: 3,
-        type: "shortAnswer",
-        quizBody:
-          "앙상블 기법 중 여러 모델이 각자 예측한 결과를 다수결로 결정하는 방법은 무엇인가요?",
-        correctRate: 50.0,
-        solution: "배깅",
-        count: 5,
-      },
-      {
-        quizId: "qz-004",
-        quizOrder: 4,
-        type: "shortAnswer",
-        quizBody:
-          "Random Forest에서 개별 변수의 중요도를 평가할 때 사용하는 데이터 샘플링 기법은 무엇인가요?",
-        correctRate: 30.0,
-        solution: "복원 추출",
-        count: 3,
-      },
-    ],
-  };
+  const [statData, setStatData] = useState<fetchQuizForDashboardResult | null>(
+    null
+  );
+  const { lectureId } = useParams<{ lectureId: string }>();
+
+  useEffect(() => {
+    if (!lectureId) return;
+    fetchQuizForDashboard(lectureId).then((res) => {
+      if (res.isSuccess && res.result) {
+        setStatData(res.result);
+      } else {
+        setStatData(null);
+      }
+    });
+  }, [lectureId]);
+
   return (
     <div className={styles.dashboardContainer}>
       <QuizInfo />
@@ -115,11 +34,19 @@ export default function DashboardContainer() {
         <section className={styles.leftSection}>
           <QuizSubmitList />
           <QuizList
-            quizList={statData.quizList}
-            totalQuizCount={statData.totalQuizCount}
+            quizList={statData?.quizList || []}
+            totalQuizCount={statData?.totalQuizCount || 0}
           />
         </section>
-        <StatisticsContainer statData={statData} />
+        <StatisticsContainer
+          statData={
+            statData || {
+              averageCorrectRate: 0,
+              totalQuizCount: 0,
+              quizList: [],
+            }
+          }
+        />
       </div>
     </div>
   );

--- a/frontend/app/teacher/quiz-dashboard/[lectureId]/_components/QuizInfo/QuizInfo.tsx
+++ b/frontend/app/teacher/quiz-dashboard/[lectureId]/_components/QuizInfo/QuizInfo.tsx
@@ -1,12 +1,9 @@
 "use client";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import styles from "./QuizInfo.module.scss";
-
-const data = {
-  title: "Ensemble 1",
-  quizDate: "2025-06-03",
-  quizDay: "화",
-};
+import { fetchQuizInfo } from "@/api/quizzes/fetchQuizInfo";
+import { useParams } from "next/navigation";
+import { fetchQuizInfoResult } from "@/types/quizzes/fetchQuizInfoTypes";
 
 function formatDate(date: string, day: string) {
   const [yyyy, mm, dd] = date.split("-");
@@ -14,13 +11,27 @@ function formatDate(date: string, day: string) {
 }
 
 export default function QuizInfo() {
+  const { lectureId } = useParams<{ lectureId: string }>();
+  const [data, setData] = useState<fetchQuizInfoResult | null>(null);
+
+  useEffect(() => {
+    if (!lectureId) return;
+    fetchQuizInfo(lectureId).then((res) => {
+      if (res.isSuccess && res.result) {
+        setData(res.result);
+      } else {
+        setData(null);
+      }
+    });
+  }, [lectureId]);
+
   return (
     <div className={styles.infoRow}>
       <div className={styles.title}>
-        [{data.title}] <span className={styles.dashboard}>퀴즈 대시보드</span>
+        [{data?.title}] <span className={styles.dashboard}>퀴즈 대시보드</span>
       </div>
       <div className={styles.date}>
-        {formatDate(data.quizDate, data.quizDay)}
+        {formatDate(data?.quizDate || "", data?.quizDay || "")}
       </div>
     </div>
   );

--- a/frontend/app/teacher/quiz-dashboard/[lectureId]/_components/QuizInfo/QuizInfo.tsx
+++ b/frontend/app/teacher/quiz-dashboard/[lectureId]/_components/QuizInfo/QuizInfo.tsx
@@ -27,12 +27,17 @@ export default function QuizInfo() {
 
   return (
     <div className={styles.infoRow}>
-      <div className={styles.title}>
-        [{data?.title}] <span className={styles.dashboard}>퀴즈 대시보드</span>
-      </div>
-      <div className={styles.date}>
-        {formatDate(data?.quizDate || "", data?.quizDay || "")}
-      </div>
+      {data && (
+        <>
+          <div className={styles.title}>
+            [{data.title}]
+            <span className={styles.dashboard}>퀴즈 대시보드</span>
+          </div>
+          <div className={styles.date}>
+            {formatDate(data.quizDate, data.quizDay)}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/app/teacher/quiz-dashboard/[lectureId]/_components/QuizSubmitList/QuizSubmitList.tsx
+++ b/frontend/app/teacher/quiz-dashboard/[lectureId]/_components/QuizSubmitList/QuizSubmitList.tsx
@@ -1,22 +1,9 @@
 "use client";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import styles from "./QuizSubmitList.module.scss";
-
-const data = {
-  submitNum: 10,
-  studentList: [
-    { name: "김클로", submitDate: "2025-06-03T15:23:00" },
-    { name: "강백호", submitDate: "2025-06-03T15:23:50" },
-    { name: "로하스", submitDate: "2025-06-03T15:26:45" },
-    { name: "허경민", submitDate: "2025-06-03T15:29:23" },
-    { name: "김민혁", submitDate: "2025-06-03T16:23:05" },
-    { name: "장성우", submitDate: "2025-06-03T16:20:59" },
-    { name: "천성호", submitDate: "2025-06-03T16:33:05" },
-    { name: "배정대", submitDate: "2025-06-03T16:52:08" },
-    { name: "김상수", submitDate: "2025-06-03T17:23:00" },
-    { name: "윤준혁", submitDate: "2025-06-03T15:23:42" },
-  ],
-};
+import { fetchQuizSubmitListResult } from "@/types/quizzes/fetchSubmitListTypes";
+import { fetchSubmitList } from "@/api/quizzes/fetchSubmitList";
+import { useParams } from "next/navigation";
 
 function formatDate(dateStr: string) {
   const d = new Date(dateStr);
@@ -29,29 +16,46 @@ function formatDate(dateStr: string) {
 }
 
 export default function QuizSubmitList() {
+  const [data, setData] = useState<fetchQuizSubmitListResult | null>(null);
+  const { lectureId } = useParams<{ lectureId: string }>();
+  useEffect(() => {
+    if (!lectureId) return;
+    fetchSubmitList(lectureId).then((res) => {
+      if (res.isSuccess && res.result) {
+        setData(res.result);
+      } else {
+        setData(null);
+      }
+    });
+  }, [lectureId]);
+
   return (
     <div className={styles.card}>
-      <div className={styles.titleRow}>
-        <span className={styles.title}>퀴즈 제출 명단</span>
-        <span className={styles.count}>응답자 총 {data.submitNum}명</span>
-      </div>
-      <div className={styles.list}>
-        {data.studentList.map((student, idx) => (
-          <div
-            className={
-              idx === data.studentList.length - 1
-                ? `${styles.row} ${styles.lastRow}`
-                : styles.row
-            }
-            key={student.name + student.submitDate}
-          >
-            <span className={styles.name}>{student.name}</span>
-            <span className={styles.date}>
-              {formatDate(student.submitDate)}
-            </span>
+      {data && (
+        <>
+          <div className={styles.titleRow}>
+            <span className={styles.title}>퀴즈 제출 명단</span>
+            <span className={styles.count}>응답자 총 {data.submitNum}명</span>
           </div>
-        ))}
-      </div>
+          <div className={styles.list}>
+            {data.studentList.map((student, idx) => (
+              <div
+                className={
+                  idx === data.studentList.length - 1
+                    ? `${styles.row} ${styles.lastRow}`
+                    : styles.row
+                }
+                key={student.name + student.submitDate}
+              >
+                <span className={styles.name}>{student.name}</span>
+                <span className={styles.date}>
+                  {formatDate(student.submitDate)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/app/teacher/quiz-dashboard/[lectureId]/_components/StatisticsContainer/AverageCorrectRate/AverageCorrectRate.tsx
+++ b/frontend/app/teacher/quiz-dashboard/[lectureId]/_components/StatisticsContainer/AverageCorrectRate/AverageCorrectRate.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { PieChart, Pie, Cell } from "recharts";
 import styles from "./AverageCorrectRate.module.scss";
 
@@ -14,29 +14,40 @@ export default function AverageCorrectRate({
   averageCorrectRate,
   totalQuizCount,
 }: AverageCorrectRateProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
   const data = [
     { name: "정답률", value: averageCorrectRate },
     { name: "오답률", value: 100 - averageCorrectRate },
   ];
+
   return (
     <div className={styles.chartCard}>
       <div className={styles.pieWrapper}>
-        <PieChart width={100} height={100}>
-          <Pie
-            data={data}
-            cx="50%"
-            cy="50%"
-            innerRadius={35}
-            outerRadius={48}
-            startAngle={90}
-            endAngle={-270}
-            dataKey="value"
-          >
-            {data.map((entry, idx) => (
-              <Cell key={`cell-${idx}`} fill={COLORS[idx % COLORS.length]} />
-            ))}
-          </Pie>
-        </PieChart>
+        {mounted ? (
+          <PieChart width={100} height={100}>
+            <Pie
+              data={data}
+              cx="50%"
+              cy="50%"
+              innerRadius={35}
+              outerRadius={48}
+              startAngle={90}
+              endAngle={-270}
+              dataKey="value"
+            >
+              {data.map((entry, idx) => (
+                <Cell key={`cell-${idx}`} fill={COLORS[idx % COLORS.length]} />
+              ))}
+            </Pie>
+          </PieChart>
+        ) : (
+          <div style={{ width: 100, height: 100 }} />
+        )}
         <div className={styles.pieCenterText}>{averageCorrectRate}%</div>
       </div>
       <div className={styles.averageCorrectRateTextBox}>

--- a/frontend/app/teacher/quiz-dashboard/[lectureId]/_components/StatisticsContainer/QuizDetailChart/QuizDetailChart.tsx
+++ b/frontend/app/teacher/quiz-dashboard/[lectureId]/_components/StatisticsContainer/QuizDetailChart/QuizDetailChart.tsx
@@ -1,23 +1,20 @@
 "use client";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { PieChart, Pie, Cell, Legend } from "recharts";
 import styles from "./QuizDetailChart.module.scss";
-
-// 타입 정의 예시
-export type QuizType = "multipleChoice" | "shortAnswer" | "trueFalse";
-export interface Quiz {
-  quizId: string;
-  quizOrder: number;
-  type: QuizType;
-  [key: string]: unknown;
-}
+import {
+  MultipleChoiceQuizDetail,
+  QuizDetailStat,
+  ShortAnswerQuizDetail,
+  TrueFalseQuizDetail,
+} from "@/types/quizzes/fetchQuizDetailStatTypes";
 
 // 색상 팔레트
 const COLORS = ["#6C5CE7", "#4F8CFF", "#6AD1C9", "#B983FF"];
 const OX_COLORS = ["#6AD1C9", "#4F8CFF"];
 
 // MultipleChoiceChart: 파이차트
-function MultipleChoiceChart({ data }: { data: Quiz }) {
+function MultipleChoiceChart({ data }: { data: MultipleChoiceQuizDetail }) {
   const chartData = [
     { name: "1번", value: Number(data["1"] ?? 0) },
     { name: "2번", value: Number(data["2"] ?? 0) },
@@ -58,7 +55,7 @@ function MultipleChoiceChart({ data }: { data: Quiz }) {
 }
 
 // TrueFalseChart: OX 파이차트
-function TrueFalseChart({ data }: { data: Quiz }) {
+function TrueFalseChart({ data }: { data: TrueFalseQuizDetail }) {
   const chartData = [
     { name: "O", value: Number(data.O ?? 0) },
     { name: "X", value: Number(data.X ?? 0) },
@@ -100,7 +97,7 @@ function TrueFalseChart({ data }: { data: Quiz }) {
 }
 
 // ShortAnswerTop3: 리스트
-function ShortAnswerTop3({ data }: { data: Quiz }) {
+function ShortAnswerTop3({ data }: { data: ShortAnswerQuizDetail }) {
   const top3 = data.top3Answers as { answer: string; rate: number }[];
   const etcAnswers = data.etcAnswers as string[] | undefined;
   return (
@@ -135,7 +132,21 @@ function ShortAnswerTop3({ data }: { data: Quiz }) {
 }
 
 // 실제 QuizDetailChart 컴포넌트
-export default function QuizDetailChart({ quiz }: { quiz: Quiz }) {
+export default function QuizDetailChart({ quiz }: { quiz: QuizDetailStat }) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <div className={styles.chartCard}>
+        <div className={styles.chartTitle}>퀴즈{quiz.quizOrder}</div>
+      </div>
+    );
+  }
+
   if (quiz.type === "multipleChoice") {
     return <MultipleChoiceChart data={quiz} />;
   }

--- a/frontend/app/teacher/quiz-dashboard/[lectureId]/_components/StatisticsContainer/StatisticsContainer.tsx
+++ b/frontend/app/teacher/quiz-dashboard/[lectureId]/_components/StatisticsContainer/StatisticsContainer.tsx
@@ -1,10 +1,17 @@
 "use client";
-import React from "react";
+
+import React, { useEffect, useState } from "react";
 import QuizCorrectRates from "./QuizCorrectRates/QuizCorrectRates";
 import AverageCorrectRate from "./AverageCorrectRate/AverageCorrectRate";
 import QuizDetailChart from "./QuizDetailChart/QuizDetailChart";
 import styles from "./StatisticsContainer.module.scss";
 import Masonry from "react-masonry-css";
+import {
+  fetchQuizDetailStatResult,
+  QuizDetailStat,
+} from "@/types/quizzes/fetchQuizDetailStatTypes";
+import { useParams } from "next/navigation";
+import { fetchQuizDetailStat } from "@/api/quizzes/fetchQuizDetailStat";
 
 interface StatData {
   averageCorrectRate: number;
@@ -23,46 +30,20 @@ export default function StatisticsContainer({
   statData,
 }: StatisticsContainerProps) {
   // 두 번째 데이터: 퀴즈별 분포/상세용
-  const detailData = [
-    {
-      quizId: "qz-001",
-      quizOrder: 1,
-      type: "multipleChoice",
-      1: 70.0,
-      2: 20.0,
-      3: 0.0,
-      4: 10.0,
-    },
-    {
-      quizId: "qz-002",
-      quizOrder: 2,
-      type: "trueFalse",
-      O: 80.0,
-      X: 20.0,
-    },
-    {
-      quizId: "qz-003",
-      quizOrder: 3,
-      type: "shortAnswer",
-      top3Answers: [
-        { answer: "배깅", rate: 50.0 },
-        { answer: "부스팅", rate: 20.0 },
-        { answer: "스태킹", rate: 10.0 },
-      ],
-      etcAnswers: ["Voting", "랜덤포레스트"],
-    },
-    {
-      quizId: "qz-004",
-      quizOrder: 4,
-      type: "shortAnswer",
-      top3Answers: [
-        { answer: "복원 추출", rate: 30.0 },
-        { answer: "순차 샘플링", rate: 20.0 },
-        { answer: "K-켭 교차 검증", rate: 10.0 },
-      ],
-      etcAnswers: ["부스트랩 샘플링", "계층 샘플링", "단순 샘플링"],
-    },
-  ];
+  const [detailData, setDetailData] =
+    useState<fetchQuizDetailStatResult | null>(null);
+  const { lectureId } = useParams<{ lectureId: string }>();
+
+  useEffect(() => {
+    if (!lectureId) return;
+    fetchQuizDetailStat(lectureId).then((res) => {
+      if (res.isSuccess && res.result) {
+        setDetailData(res.result);
+      } else {
+        setDetailData(null);
+      }
+    });
+  }, [lectureId]);
 
   return (
     <Masonry
@@ -75,15 +56,13 @@ export default function StatisticsContainer({
         totalQuizCount={statData.totalQuizCount}
       />
       <QuizCorrectRates quizList={statData.quizList} />
-      {detailData.map((quiz) => (
-        <QuizDetailChart
-          key={quiz.quizId}
-          quiz={{
-            ...quiz,
-            type: quiz.type as "multipleChoice" | "trueFalse" | "shortAnswer",
-          }}
-        />
-      ))}
+      {detailData && detailData.length > 0 ? (
+        detailData.map((quiz: QuizDetailStat) => (
+          <QuizDetailChart key={quiz.quizId} quiz={quiz} />
+        ))
+      ) : (
+        <div className={styles.noData}>퀴즈 상세 통계 데이터가 없습니다.</div>
+      )}
     </Masonry>
   );
 }

--- a/frontend/app/teacher/quiz-dashboard/[lectureId]/page.tsx
+++ b/frontend/app/teacher/quiz-dashboard/[lectureId]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import BackButtonHeader from "./_components/BackButtonHeader/BackButtonHeader";
 import DashboardContainer from "./_components/DashboardContainer/DashboardContainer";
 import style from "./page.module.scss";

--- a/frontend/app/teacher/quiz-list/[lectureId]/_components/BackButtonHeader/BackButtonHeader.module.scss
+++ b/frontend/app/teacher/quiz-list/[lectureId]/_components/BackButtonHeader/BackButtonHeader.module.scss
@@ -1,0 +1,18 @@
+.quizHeader {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    height: 6vh;
+  }
+  
+  .backBtn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    width: 40px;
+    height: 40px;
+    cursor: pointer;
+    background-color: white;
+  }
+  

--- a/frontend/app/teacher/quiz-list/[lectureId]/_components/BackButtonHeader/BackButtonHeader.tsx
+++ b/frontend/app/teacher/quiz-list/[lectureId]/_components/BackButtonHeader/BackButtonHeader.tsx
@@ -1,0 +1,21 @@
+"use client";
+import React from "react";
+import { ArrowLeft } from "lucide-react";
+import styles from "./BackButtonHeader.module.scss";
+import IconButton from "@/components/Button/IconButton/IconButton";
+import { useRouter } from "next/navigation";
+import { ROUTES } from "@/constants/routes";
+
+export default function BackButtonHeader() {
+  const router = useRouter();
+
+  return (
+    <header className={styles.quizHeader}>
+      <IconButton
+        icon={<ArrowLeft />}
+        onClick={() => router.push(ROUTES.teacherQuizManagement)}
+        ariaLabel={""}
+      ></IconButton>
+    </header>
+  );
+}

--- a/frontend/app/teacher/quiz-list/[lectureId]/_components/QuizInfo/QuizInfo.module.scss
+++ b/frontend/app/teacher/quiz-list/[lectureId]/_components/QuizInfo/QuizInfo.module.scss
@@ -1,0 +1,20 @@
+.infoRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.title {
+  font-size: $font-size-xl;
+  font-weight: $font-weight-bold;
+}
+
+.dashboard {
+  font-weight: $font-weight-medium;
+}
+
+.date {
+  font-size: $font-size-lg;
+  color: $color-blue;
+}

--- a/frontend/app/teacher/quiz-list/[lectureId]/_components/QuizInfo/QuizInfo.tsx
+++ b/frontend/app/teacher/quiz-list/[lectureId]/_components/QuizInfo/QuizInfo.tsx
@@ -1,12 +1,9 @@
 "use client";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import styles from "./QuizInfo.module.scss";
-
-const data = {
-  title: "Ensemble 1",
-  quizDate: "2025-06-03",
-  quizDay: "화",
-};
+import { fetchQuizInfo } from "@/api/quizzes/fetchQuizInfo";
+import { useParams } from "next/navigation";
+import { fetchQuizInfoResult } from "@/types/quizzes/fetchQuizInfoTypes";
 
 function formatDate(date: string, day: string) {
   const [yyyy, mm, dd] = date.split("-");
@@ -14,14 +11,33 @@ function formatDate(date: string, day: string) {
 }
 
 export default function QuizInfo() {
+  const { lectureId } = useParams<{ lectureId: string }>();
+  const [data, setData] = useState<fetchQuizInfoResult | null>(null);
+
+  useEffect(() => {
+    if (!lectureId) return;
+    fetchQuizInfo(lectureId).then((res) => {
+      if (res.isSuccess && res.result) {
+        setData(res.result);
+      } else {
+        setData(null);
+      }
+    });
+  }, [lectureId]);
+
   return (
     <div className={styles.infoRow}>
-      <div className={styles.title}>
-        [{data.title}] <span className={styles.dashboard}>퀴즈</span>
-      </div>
-      <div className={styles.date}>
-        {formatDate(data.quizDate, data.quizDay)}
-      </div>
+      {data && (
+        <>
+          <div className={styles.title}>
+            [{data.title}]
+            <span className={styles.dashboard}> 퀴즈</span>
+          </div>
+          <div className={styles.date}>
+            {formatDate(data.quizDate, data.quizDay)}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/app/teacher/quiz-list/[lectureId]/_components/QuizInfo/QuizInfo.tsx
+++ b/frontend/app/teacher/quiz-list/[lectureId]/_components/QuizInfo/QuizInfo.tsx
@@ -1,0 +1,27 @@
+"use client";
+import React from "react";
+import styles from "./QuizInfo.module.scss";
+
+const data = {
+  title: "Ensemble 1",
+  quizDate: "2025-06-03",
+  quizDay: "화",
+};
+
+function formatDate(date: string, day: string) {
+  const [yyyy, mm, dd] = date.split("-");
+  return `${yyyy}.${mm}.${dd} (${day})`;
+}
+
+export default function QuizInfo() {
+  return (
+    <div className={styles.infoRow}>
+      <div className={styles.title}>
+        [{data.title}] <span className={styles.dashboard}>퀴즈</span>
+      </div>
+      <div className={styles.date}>
+        {formatDate(data.quizDate, data.quizDay)}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/teacher/quiz-list/[lectureId]/_components/QuizListContainer/QuizListContainer.module.scss
+++ b/frontend/app/teacher/quiz-list/[lectureId]/_components/QuizListContainer/QuizListContainer.module.scss
@@ -1,0 +1,32 @@
+.quizListContainer {
+  background-color: white;
+  border-radius: $radius-lg;
+  padding: $spacing-lg;
+  border: 1px solid $color-neutral-7;
+  height: calc(94vh - $spacing-lg);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-md;
+}
+
+.quizListContainerInner {
+  height: 100%;
+  display: flex;
+  gap: $spacing-md;
+}
+
+.leftSection {
+  width: 55%;
+  height: 100%;
+  display: flex;
+  gap: $spacing-md;
+}
+
+.loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 60vh;
+}
+

--- a/frontend/app/teacher/quiz-list/[lectureId]/_components/QuizListContainer/QuizListContainer.tsx
+++ b/frontend/app/teacher/quiz-list/[lectureId]/_components/QuizListContainer/QuizListContainer.tsx
@@ -1,0 +1,16 @@
+"use client";
+import React from "react";
+import styles from "./QuizListContainer.module.scss";
+import QuizSection from "../QuizSection/QuizSection";
+import QuizInfo from "../QuizInfo/QuizInfo";
+
+export default function QuizListContainer() {
+  return (
+    <div className={styles.quizListContainer}>
+      <QuizInfo />
+      <div className={styles.quizListContainerInner}>
+        <QuizSection />
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/teacher/quiz-list/[lectureId]/_components/QuizSection/QuizSection.module.scss
+++ b/frontend/app/teacher/quiz-list/[lectureId]/_components/QuizSection/QuizSection.module.scss
@@ -1,0 +1,118 @@
+.wrapper {
+    width: 100%;
+    margin: 0;
+    max-width: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-md;
+}
+  
+.sectionTitle {
+    font-size: $font-size-lg;
+    font-weight: bold;
+    margin-bottom: $spacing-sm;
+    border-bottom: 1px solid $color-neutral-6;
+    padding-bottom: $spacing-xs;
+    color: $color-neutral-2;
+}
+  
+.quizGrid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: $spacing-lg;
+  
+    @include respond-to(md) {
+      grid-template-columns: 1fr;
+    }
+}
+  
+.quizBox {
+    background: $color-skyblue;
+    border-radius: $radius-md;
+    padding: $spacing-lg;
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-sm;
+    border: 1px solid lighten($color-blue, 35%);
+}
+  
+.question::before {
+    content: "문제: ";
+    color: $color-blue;
+    font-weight: 800;
+    margin-right: $spacing-xs;
+}
+  
+.optionList {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-xs;
+}
+  
+.optionRow {
+    display: flex;
+    align-items: center;
+    gap: $spacing-sm;
+  
+    .optionNumber {
+      font-weight: bold;
+      color: $color-blue;
+      width: $spacing-lg;
+      text-align: right;
+    }
+  
+    .optionText {
+        flex: 1;
+        background: $color-white;
+        border-radius: $radius-sm;
+        padding: $spacing-xs $spacing-sm;
+        border: 1px solid $color-neutral-6;
+        font-size: $font-size-md;
+    }
+}
+  
+.answerRow {
+    display: flex;
+    align-items: center;
+    gap: $spacing-sm;
+    margin-top: $spacing-xs;
+  
+    .label {
+      font-weight: bold;
+      color: $color-neutral-5;
+    }
+  
+    .answerBtn {
+        border: 1px solid $color-neutral-6;
+        background: $color-white;
+        border-radius: $radius-full;
+        padding: $spacing-xs $spacing-sm;
+        font-size: $font-size-md;
+        color: $color-neutral-5;
+        transition: border 0.2s, color 0.2s;
+    
+        &.selected {
+            border: 2px solid $color-blue;
+            color: $color-blue;
+            font-weight: bold;
+            background: $color-skyblue;
+        }
+    }
+  
+    .shortAnswer {
+      display: inline-block;
+      background: $color-white;
+      border: 1px solid $color-neutral-6;
+      border-radius: $radius-sm;
+      padding: $spacing-xs $spacing-sm;
+      font-size: $font-size-sm;
+      color: $color-neutral-2;
+    }
+}
+  
+.oxBox,
+.shortBox {
+    background: $color-skyblue;
+    border: 1px solid lighten($color-blue, 35%);
+}

--- a/frontend/app/teacher/quiz-list/[lectureId]/_components/QuizSection/QuizSection.tsx
+++ b/frontend/app/teacher/quiz-list/[lectureId]/_components/QuizSection/QuizSection.tsx
@@ -3,14 +3,14 @@
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import { fetchQuizList } from "@/api/quizzes/fetchQuizList";
-import { Quiz } from "@/types/quizzes/createQuizTypes";
+import { fetchQuizListResult } from "@/types/quizzes/fetchQuizListTypes";
 import styles from "./QuizSection.module.scss";
 import LoadingSpinner from "@/components/LoadingSpinner/LoadingSpinner";
 import AlertModal from "@/components/Modal/AlertModal/AlertModal";
 
 export default function QuizSection() {
   const { lectureId } = useParams();
-  const [quizzes, setQuizzes] = useState<Quiz[]>([]);
+  const [quizzes, setQuizzes] = useState<fetchQuizListResult["quizzes"][number][]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -24,10 +24,11 @@ export default function QuizSection() {
         if (res.isSuccess && res.result?.quizzes) {
           const mapped = res.result.quizzes.map((q) => ({
             quizId: q.quizId,
+            quizOrder: q.quizOrder,
             quizBody: q.quizBody,
             solution: q.solution,
             type: q.type,
-            options: q.options?.map((opt) => opt.text) || [],
+            options: q.options,
           }));
 
           setQuizzes(mapped);
@@ -69,10 +70,8 @@ export default function QuizSection() {
       <h3 className={styles.sectionTitle}>객관식</h3>
       <div className={styles.quizGrid}>
         {multipleChoice.map((quiz) => (
-          <div className={styles.quizBox}>
-            <div className={styles.question}>
-              {quiz.quizBody}
-            </div>
+          <div key={quiz.quizId} className={styles.quizBox}>
+            <div className={styles.question}>{quiz.quizBody}</div>
 
             <div className={styles.optionList}>
               {quiz.options?.map((opt, i) => (
@@ -80,10 +79,10 @@ export default function QuizSection() {
                   <span className={styles.optionNumber}>{i + 1}</span>
                   <div
                     className={`${styles.optionText} ${
-                      opt === quiz.solution ? styles.selectedOption : ""
+                      opt.text === quiz.solution ? styles.selectedOption : ""
                     }`}
                   >
-                    {opt}
+                    {opt.text}
                   </div>
                 </div>
               ))}
@@ -101,10 +100,8 @@ export default function QuizSection() {
       <h3 className={styles.sectionTitle}>O/X</h3>
       <div className={styles.quizGrid}>
         {ox.map((quiz) => (
-          <div className={`${styles.quizBox} ${styles.oxBox}`}>
-            <div className={styles.question}>
-              {quiz.quizBody}
-            </div>
+          <div key={quiz.quizId} className={`${styles.quizBox} ${styles.oxBox}`}>
+            <div className={styles.question}>{quiz.quizBody}</div>
             <div className={styles.answerRow}>
               <span className={styles.label}>정답:</span>
               {["O", "X"].map((v) => (
@@ -126,10 +123,8 @@ export default function QuizSection() {
       <h3 className={styles.sectionTitle}>단답형</h3>
       <div className={styles.quizGrid}>
         {short.map((quiz) => (
-          <div className={`${styles.quizBox} ${styles.shortBox}`}>
-            <div className={styles.question}>
-              {quiz.quizBody}
-            </div>
+          <div key={quiz.quizId} className={`${styles.quizBox} ${styles.shortBox}`}>
+            <div className={styles.question}>{quiz.quizBody}</div>
             <div className={styles.answerRow}>
               <span className={styles.label}>정답:</span>
               <span className={styles.shortAnswer}>{quiz.solution}</span>

--- a/frontend/app/teacher/quiz-list/[lectureId]/_components/QuizSection/QuizSection.tsx
+++ b/frontend/app/teacher/quiz-list/[lectureId]/_components/QuizSection/QuizSection.tsx
@@ -103,7 +103,7 @@ export default function QuizSection() {
         {ox.map((quiz) => (
           <div className={`${styles.quizBox} ${styles.oxBox}`}>
             <div className={styles.question}>
-              <strong>문제:</strong> {quiz.quizBody}
+              {quiz.quizBody}
             </div>
             <div className={styles.answerRow}>
               <span className={styles.label}>정답:</span>
@@ -128,7 +128,7 @@ export default function QuizSection() {
         {short.map((quiz) => (
           <div className={`${styles.quizBox} ${styles.shortBox}`}>
             <div className={styles.question}>
-              <strong>문제:</strong> {quiz.quizBody}
+              {quiz.quizBody}
             </div>
             <div className={styles.answerRow}>
               <span className={styles.label}>정답:</span>

--- a/frontend/app/teacher/quiz-list/[lectureId]/_components/QuizSection/QuizSection.tsx
+++ b/frontend/app/teacher/quiz-list/[lectureId]/_components/QuizSection/QuizSection.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { fetchQuizList } from "@/api/quizzes/fetchQuizList";
+import { Quiz } from "@/types/quizzes/createQuizTypes";
+import styles from "./QuizSection.module.scss";
+import LoadingSpinner from "@/components/LoadingSpinner/LoadingSpinner";
+import AlertModal from "@/components/Modal/AlertModal/AlertModal";
+
+export default function QuizSection() {
+  const { lectureId } = useParams();
+  const [quizzes, setQuizzes] = useState<Quiz[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!lectureId || typeof lectureId !== "string") return;
+
+    const loadQuizzes = async () => {
+      try {
+        const res = await fetchQuizList(lectureId);
+
+        if (res.isSuccess && res.result?.quizzes) {
+          const mapped = res.result.quizzes.map((q) => ({
+            quizId: q.quizId,
+            quizBody: q.quizBody,
+            solution: q.solution,
+            type: q.type,
+            options: q.options?.map((opt) => opt.text) || [],
+          }));
+
+          setQuizzes(mapped);
+        } else {
+          setError("퀴즈 목록을 불러오지 못했습니다.");
+        }
+      } catch {
+        setError("퀴즈 데이터를 불러오는 중 오류가 발생했습니다.");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadQuizzes();
+  }, [lectureId]);
+
+  if (isLoading)
+    return (
+      <div className={styles.loading}>
+        <LoadingSpinner
+          text={["퀴즈 목록을 불러오는 중이에요", "잠시만 기다려주세요!"]}
+        />
+      </div>
+    );
+
+  if (error)
+    return <AlertModal onClose={() => setError(null)}>{error}</AlertModal>;
+
+  if (quizzes.length === 0)
+    return <div className={styles.emptyBox}>등록된 퀴즈가 없습니다.</div>;
+
+  const multipleChoice = quizzes.filter((q) => q.type === "multipleChoice");
+  const ox = quizzes.filter((q) => q.type === "trueFalse");
+  const short = quizzes.filter((q) => q.type === "shortAnswer");
+
+  return (
+    <div className={styles.wrapper}>
+      {/* 객관식 */}
+      <h3 className={styles.sectionTitle}>객관식</h3>
+      <div className={styles.quizGrid}>
+        {multipleChoice.map((quiz) => (
+          <div className={styles.quizBox}>
+            <div className={styles.question}>
+              {quiz.quizBody}
+            </div>
+
+            <div className={styles.optionList}>
+              {quiz.options?.map((opt, i) => (
+                <div key={i} className={styles.optionRow}>
+                  <span className={styles.optionNumber}>{i + 1}</span>
+                  <div
+                    className={`${styles.optionText} ${
+                      opt === quiz.solution ? styles.selectedOption : ""
+                    }`}
+                  >
+                    {opt}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className={styles.answerRow}>
+              <span className={styles.label}>정답:</span>
+              <span className={styles.correctAnswer}>{quiz.solution}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* OX */}
+      <h3 className={styles.sectionTitle}>O/X</h3>
+      <div className={styles.quizGrid}>
+        {ox.map((quiz) => (
+          <div className={`${styles.quizBox} ${styles.oxBox}`}>
+            <div className={styles.question}>
+              <strong>문제:</strong> {quiz.quizBody}
+            </div>
+            <div className={styles.answerRow}>
+              <span className={styles.label}>정답:</span>
+              {["O", "X"].map((v) => (
+                <span
+                  key={v}
+                  className={`${styles.answerBtn} ${
+                    quiz.solution === v ? styles.selected : ""
+                  }`}
+                >
+                  {v}
+                </span>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* 단답형 */}
+      <h3 className={styles.sectionTitle}>단답형</h3>
+      <div className={styles.quizGrid}>
+        {short.map((quiz) => (
+          <div className={`${styles.quizBox} ${styles.shortBox}`}>
+            <div className={styles.question}>
+              <strong>문제:</strong> {quiz.quizBody}
+            </div>
+            <div className={styles.answerRow}>
+              <span className={styles.label}>정답:</span>
+              <span className={styles.shortAnswer}>{quiz.solution}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/teacher/quiz-list/[lectureId]/page.module.scss
+++ b/frontend/app/teacher/quiz-list/[lectureId]/page.module.scss
@@ -1,0 +1,5 @@
+.quizListPage {
+    width: 100%;
+    height: 100%;
+    padding: 0px $spacing-lg $spacing-lg $spacing-lg;
+}

--- a/frontend/app/teacher/quiz-list/[lectureId]/page.tsx
+++ b/frontend/app/teacher/quiz-list/[lectureId]/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+import BackButtonHeader from "./_components/BackButtonHeader/BackButtonHeader";
+import QuizListContainer from "./_components/QuizListContainer/QuizListContainer";
+import style from "./page.module.scss";
+
+export default function TeacherQuizListPage() {
+  return (
+    <div className={style.quizListPage}>
+      <BackButtonHeader />
+      <QuizListContainer />
+    </div>
+  );
+}

--- a/frontend/app/teacher/quiz-management/page.module.scss
+++ b/frontend/app/teacher/quiz-management/page.module.scss
@@ -21,7 +21,7 @@
   display: flex;
   flex-direction: column;
   gap: $spacing-lg;
-  padding-bottom: $spacing-xl;
+  padding: $spacing-xl 0;
 }
 
 .lectureItem {

--- a/frontend/components/Modal/MakeQuizModal/QuizPreview/QuizPreview.tsx
+++ b/frontend/components/Modal/MakeQuizModal/QuizPreview/QuizPreview.tsx
@@ -46,6 +46,7 @@ const QuizPreview = ({
 
   const [showAlert, setShowAlert] = useState(false);
   const [showPreviewModal, setShowPreviewModal] = useState(false);
+  const [hasClickedMore, setHasClickedMore] = useState(false);
 
   // 현재 lectureId의 퀴즈 가져오기
   const quizzes = getQuizzes(lectureId);
@@ -56,6 +57,10 @@ const QuizPreview = ({
 
     setIsLoading(true);
     setError(null);
+
+    // 현재 시간
+    const startTime = Date.now();
+
     createQuiz({ lectureId, useAudio })
       .then((res) => {
         if (res.isSuccess && res.result && Array.isArray(res.result.quizzes)) {
@@ -70,8 +75,16 @@ const QuizPreview = ({
         setError("퀴즈 생성 중 오류가 발생했습니다.");
       })
       .finally(() => {
+
+        // 로딩 시간
+        const elapsed = Date.now() - startTime;
+        const minLoadingTime = 40000 + Math.random() * 10000;
+        const remaining = Math.max(0, minLoadingTime - elapsed);
+
+        setTimeout(() => {
         setIsLoading(false);
-      });
+      }, remaining);
+    });
   }, [
     lectureId,
     shouldGenerateQuiz,
@@ -101,9 +114,10 @@ const QuizPreview = ({
   };
 
   const handleMoreQuiz = () => {
-    if (!quizzes) return;
+    if (isLoadingMore || !quizzes || hasClickedMore) return;
 
     setIsLoadingMore(true);
+    setHasClickedMore(true);
     setError(null);
 
     recreateQuiz({ lectureId, useAudio })
@@ -213,17 +227,20 @@ const QuizPreview = ({
                   </div>
                 ))}
               </Masonry>
-              <div className={styles.moreQuiz} onClick={handleMoreQuiz}>
+
+              {!hasClickedMore && (
+                <div className={styles.moreQuiz} onClick={handleMoreQuiz}>
                 <p>
                   {isLoadingMore
                     ? "추가 퀴즈를 생성하고 있어요..."
                     : "+ 다른 퀴즈도 보고싶어요"}
                 </p>
               </div>
+              )}
             </div>
           )}
         </div>
-        {quizzes !== null && (
+        {quizzes !== null && !isLoading && (
           <div className={styles.buttonSection}>
             <button
               className={styles.customizing}
@@ -244,7 +261,7 @@ const QuizPreview = ({
       </div>
 
       {/* 제출 전 미리보기 모달 */}
-      {showPreviewModal && (
+      {showPreviewModal && !isLoading && (
         <QuizPreviewModal
           quizzes={selectedQuizzes}
           onClose={() => setShowPreviewModal(false)}

--- a/frontend/config/teacherRouteConfig.ts
+++ b/frontend/config/teacherRouteConfig.ts
@@ -23,6 +23,7 @@ export const TEACHER_ROUTE_CONFIG: Record<
     | "teacherSetting"
     | "teacherStudentManagement"
     | "teacherLectureLive"
+    | "teacherQuizList"
     >,
   RouteConfig
 > = {
@@ -58,6 +59,11 @@ export const TEACHER_ROUTE_CONFIG: Record<
   },
   teacherLectureLive: {
     path: ROUTES.teacherLectureLive,
+    headerType: TeacherHeaderType.NONE,
+    sidebarType: SiderbarType.NONE,
+  },
+  teacherQuizList: {
+    path: ROUTES.teacherQuizList,
     headerType: TeacherHeaderType.NONE,
     sidebarType: SiderbarType.NONE,
   },

--- a/frontend/constants/endpoints.ts
+++ b/frontend/constants/endpoints.ts
@@ -111,6 +111,8 @@ export const ENDPOINTS = {
     SAVE: (lectureId: string) => `${BASE_API}/quizzes/${lectureId}/save`,
     UPDATE: (lectureId: string) => `${BASE_API}/quizzes/${lectureId}`,
     GET: (lectureId: string) => `${BASE_API}/quizzes/${lectureId}`,
+    GET_FOR_DASHBOARD: (lectureId: string) =>
+      `${BASE_API}/quizzes/${lectureId}/result`,
     SUBMIT: `${BASE_API}/quizzes/submit`,
     GET_RESULT: (lectureId: string) =>
       `${BASE_API}/quizzes/${lectureId}/result/student`,

--- a/frontend/constants/endpoints.ts
+++ b/frontend/constants/endpoints.ts
@@ -105,6 +105,8 @@ export const ENDPOINTS = {
 
   // 퀴즈 관련
   QUIZZES: {
+    GET_INFO: (lectureId: string) =>
+      `${BASE_API}/quizzes/${lectureId}/result/info`,
     CREATE: (lectureId: string) => `${BASE_API}/quizzes/${lectureId}/create`,
     RECREATE: (lectureId: string) =>
       `${BASE_API}/quizzes/${lectureId}/re-create`,

--- a/frontend/constants/endpoints.ts
+++ b/frontend/constants/endpoints.ts
@@ -105,6 +105,8 @@ export const ENDPOINTS = {
 
   // 퀴즈 관련
   QUIZZES: {
+    GET_DETAIL_STAT: (lectureId: string) =>
+      `${BASE_API}/quizzes/${lectureId}/result/statistics`,
     GET_SUBMIT_LIST: (lectureId: string) =>
       `${BASE_API}/quizzes/${lectureId}/result/list`,
     GET_INFO: (lectureId: string) =>

--- a/frontend/constants/endpoints.ts
+++ b/frontend/constants/endpoints.ts
@@ -105,6 +105,8 @@ export const ENDPOINTS = {
 
   // 퀴즈 관련
   QUIZZES: {
+    GET_SUBMIT_LIST: (lectureId: string) =>
+      `${BASE_API}/quizzes/${lectureId}/result/list`,
     GET_INFO: (lectureId: string) =>
       `${BASE_API}/quizzes/${lectureId}/result/info`,
     CREATE: (lectureId: string) => `${BASE_API}/quizzes/${lectureId}/create`,

--- a/frontend/constants/routes.ts
+++ b/frontend/constants/routes.ts
@@ -26,6 +26,8 @@ export const ROUTES = {
     `/teacher/lecture-detail/${lectureId}`, // 강사 강의 상세
   teacherLectureLive: (lectureId: string) => 
     `/teacher/lecture-live/${lectureId}`, // 강사 실시간 강의
+  teacherQuizList: (lectureId: string) =>
+    `/teacher/quiz-list/${lectureId}`, // 강사 퀴즈 문제
   teacherSetting: "/teacher/setting", // 강사 설정
   teacherStudentManagement: "/teacher/student-management", // 강사 학생 관리
   teacherNotification: "/teacher/notification", // 강사 알림 관리

--- a/frontend/hooks/useLectureStatusAction.ts
+++ b/frontend/hooks/useLectureStatusAction.ts
@@ -59,15 +59,18 @@ export const useLectureStatusAction = ({
         const midnight = lectureDateObj.add(1, "day").startOf("day");
         const isBeforeMidnight = now.isBefore(midnight);
 
+        // 아직 자정 전이라면 -> "퀴즈 확인하기"
         if (isToday && isBeforeMidnight) {
           return {
-            text: "오늘 밤 12:00 확인 가능",
-            disabled: true,
-            className: "showDashboardNotYet",
+            text: "퀴즈 확인하기",
+            onClick: () => router.push(ROUTES.teacherQuizList(lectureId)),
+            icon: ChevronRight,
+            className: "checkQuiz",
           };
         }
       }
 
+      // 자정 이후 -> "대시보드 확인하기"
       return {
         text: "대시보드 확인하기",
         onClick: () => router.push(ROUTES.teacherQuizDashboard(lectureId)),

--- a/frontend/types/quizzes/fetchQuizDetailStatTypes.ts
+++ b/frontend/types/quizzes/fetchQuizDetailStatTypes.ts
@@ -1,0 +1,35 @@
+export type fetchQuizDetailStatResult = QuizDetailStat[];
+
+export type QuizDetailStat =
+  | MultipleChoiceQuizDetail
+  | TrueFalseQuizDetail
+  | ShortAnswerQuizDetail;
+
+export interface MultipleChoiceQuizDetail {
+  quizId: string;
+  quizOrder: number;
+  type: "multipleChoice";
+  "1": number;
+  "2": number;
+  "3": number;
+  "4": number;
+}
+
+export interface TrueFalseQuizDetail {
+  quizId: string;
+  quizOrder: number;
+  type: "trueFalse";
+  O: number;
+  X: number;
+}
+
+export interface ShortAnswerQuizDetail {
+  quizId: string;
+  quizOrder: number;
+  type: "shortAnswer";
+  top3Answers: Array<{
+    answer: string;
+    rate: number;
+  }>;
+  etcAnswers: string[];
+}

--- a/frontend/types/quizzes/fetchQuizForDashboardTypes.ts
+++ b/frontend/types/quizzes/fetchQuizForDashboardTypes.ts
@@ -1,0 +1,34 @@
+export interface fetchQuizForDashboardResult {
+  totalQuizCount: number;
+  averageCorrectRate: number;
+  quizList: Quiz[];
+}
+
+type Quiz =
+  | {
+      quizId: string;
+      quizOrder: number;
+      type: "multipleChoice";
+      quizBody: string;
+      correctRate: number;
+      solution: string;
+      options: Array<{ optionOrder: number; option: string; count: number }>;
+    }
+  | {
+      quizId: string;
+      quizOrder: number;
+      type: "trueFalse";
+      quizBody: string;
+      correctRate: number;
+      solution: string;
+      options: Array<{ optionOrder: null; option: string; count: number }>;
+    }
+  | {
+      quizId: string;
+      quizOrder: number;
+      type: "shortAnswer";
+      quizBody: string;
+      correctRate: number;
+      solution: string;
+      count: number;
+    };

--- a/frontend/types/quizzes/fetchQuizInfoTypes.ts
+++ b/frontend/types/quizzes/fetchQuizInfoTypes.ts
@@ -1,0 +1,5 @@
+export interface fetchQuizInfoResult {
+  title: string;
+  quizDate: string;
+  quizDay: string;
+}

--- a/frontend/types/quizzes/fetchSubmitListTypes.ts
+++ b/frontend/types/quizzes/fetchSubmitListTypes.ts
@@ -1,0 +1,7 @@
+export interface fetchQuizSubmitListResult {
+  submitNum: number;
+  studentList: {
+    name: string;
+    submitDate: string;
+  }[];
+}


### PR DESCRIPTION
### 👀 관련 이슈

#365 
<!-- 관련 이슈를 적어주세요 -->

### ✨ 작업한 내용

- 퀴즈 생성 로직 변경
- 대시보드 확인 전까지 퀴즈 문제 확인할 수 있도록 퀴즈 확인 상태, 페이지 추가
<!-- 작업한 내용을 적어주세요 -->

### 🌀 PR Point

- 퀴즈 생성, 재생성 잘 되는지 확인해주세요.
- 퀴즈 생성했을 때 '퀴즈 확인'으로 변경 되는지 확인해주세요.
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

#363 브랜치 풀 당겨서 진행해서 커밋 내용이 겹쳤습니다.
<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|   퀴즈 확인 상태   |     <img width="1795" height="912" alt="Image" src="https://github.com/user-attachments/assets/48e9ac2e-8ec9-40ea-b84f-b6bd5f1a3cfc" />     |
|   퀴즈 확인 페이지   |    <img width="1797" height="919" alt="Image" src="https://github.com/user-attachments/assets/5ee59053-9e06-4144-8cab-910736f0a04c" />     |